### PR TITLE
Fixed sign in and sign out

### DIFF
--- a/GoogleSignin.android.js
+++ b/GoogleSignin.android.js
@@ -21,6 +21,7 @@ const RNGoogleSigninButton = requireNativeComponent('RNGoogleSigninButton', {
 class GoogleSigninButton extends Component {
   componentDidMount() {
     this._clickListener = DeviceEventEmitter.addListener('RNGoogleSigninButtonClicked', () => {
+      GoogleSigninSingleton.signIn()
       this.props.onPress && this.props.onPress();
     });
 
@@ -170,4 +171,6 @@ class GoogleSignin {
   }
 }
 
-module.exports = {GoogleSignin: new GoogleSignin(), GoogleSigninButton};
+const GoogleSigninSingleton = new GoogleSignin();
+
+module.exports = {GoogleSignin: GoogleSigninSingleton, GoogleSigninButton};

--- a/GoogleSignin.android.js
+++ b/GoogleSignin.android.js
@@ -86,7 +86,10 @@ class GoogleSignin {
         this._user = user;
 
         RNGoogleSignin.getAccessToken(user).then((token) => {
-          this._user.accessToken = token;
+          this._user = {
+            ...user,
+            accessToken: token
+          };
           this._removeListeners(sucessCb, errorCb);
           resolve(this._user);
         })
@@ -114,7 +117,10 @@ class GoogleSignin {
       const sucessCb = DeviceEventEmitter.addListener('RNGoogleSignInSuccess', (user) => {
         this._user = user;
         RNGoogleSignin.getAccessToken(user).then((token) => {
-          this._user.accessToken = token;
+          this._user = {
+            ...user,
+            accessToken: token
+          };
           this._removeListeners(sucessCb, errorCb);
           resolve(this._user);
         })

--- a/GoogleSignin.android.js
+++ b/GoogleSignin.android.js
@@ -23,10 +23,15 @@ class GoogleSigninButton extends Component {
     this._clickListener = DeviceEventEmitter.addListener('RNGoogleSigninButtonClicked', () => {
       this.props.onPress && this.props.onPress();
     });
+
+    this._signInListener = DeviceEventEmitter.addListener('RNGoogleSignInSuccess', (user) => {
+      GoogleSigninSingleton._user = user;
+    });
   }
 
   componentWillUnmount() {
     this._clickListener && this._clickListener.remove();
+    this._signInListener && this._signInListener.remove();
   }
 
   render() {

--- a/GoogleSignin.ios.js
+++ b/GoogleSignin.ios.js
@@ -118,6 +118,7 @@ class GoogleSignin {
 
   signOut() {
     return new Promise((resolve, reject) => {
+      this._user = null;
       RNGoogleSignin.signOut();
       resolve();
     });

--- a/GoogleSignin.ios.js
+++ b/GoogleSignin.ios.js
@@ -17,10 +17,16 @@ class GoogleSigninButton extends Component {
       GoogleSigninSingleton.signinIsInProcess = true;
       this.props.onPress && this.props.onPress();
     });
+
+    this._signInListener = NativeAppEventEmitter.addListener('RNGoogleSignInSuccess', (user) => {
+      GoogleSigninSingleton._user = user;
+      GoogleSigninSingleton.signinIsInProcess = false;
+    });
   }
 
   componentWillUnmount() {
     this._clickListener && this._clickListener.remove();
+    this._signInListener && this._signInListener.remove();
   }
 
   render() {


### PR DESCRIPTION
When calling the currentUser method after using the sign in button, the current user would return null, changed the component to set it after sign in.

On ios, after calling the logout method, the current user was not being reset, calling currentUser would return the old user.

On Android, the signIn method was never called after clicking on the button, changed the listener to call the singleton signIn method when clicked.

This PR fixes these issues.