### PR TITLE
Cocoapod Podspec for this Package

### DIFF
--- a/RNGoogleSignin.podspec
+++ b/RNGoogleSignin.podspec
@@ -9,9 +9,9 @@ Pod::Spec.new do |s|
   s.description         = <<-DESC
                             Pod file to enable linking code from React Native Google Signing and Google/Signing Pod.
                          DESC
-  s.homepage            = "http://facebook.github.io/react-native/"
+  s.homepage            = "https://github.com/devfd/react-native-google-signin"
   s.license             = package['license']
-  s.author              = "Radical Candor"
+  s.author              = "devfd & TJ Pavlu"
   s.source              = { :git => "https://github.com/devfd/react-native-google-signin", :tag => "v#{s.version}" }
   s.default_subspec     = 'Core'
   s.requires_arc        = true

--- a/RNGoogleSignin.podspec
+++ b/RNGoogleSignin.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   s.preserve_paths      = "package.json", "LICENSE", "LICENSE-CustomComponents", "PATENTS"
 
   s.subspec 'Core' do |ss|
-    # ss.dependency      'Google/Signin'
+    ss.dependency      'GoogleSignIn'
     ss.source_files  = "ios/**/*.{c,h,m,mm,S}"
     ss.libraries     = "stdc++"
   end

--- a/RNGoogleSignin.podspec
+++ b/RNGoogleSignin.podspec
@@ -22,6 +22,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'Core' do |ss|
     ss.dependency      'GoogleSignIn'
+    ss.dependency      'React'
     ss.source_files  = "ios/**/*.{c,h,m,mm,S}"
     ss.libraries     = "stdc++"
   end

--- a/RNGoogleSignin.podspec
+++ b/RNGoogleSignin.podspec
@@ -1,0 +1,28 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name                = "RNGoogleSignin"
+  s.version             = package['version']
+  s.summary             = package['description']
+  s.description         = <<-DESC
+                            Pod file to enable linking code from React Native Google Signing and Google/Signing Pod.
+                         DESC
+  s.homepage            = "http://facebook.github.io/react-native/"
+  s.license             = package['license']
+  s.author              = "Radical Candor"
+  s.source              = { :git => "https://github.com/devfd/react-native-google-signin", :tag => "v#{s.version}" }
+  s.default_subspec     = 'Core'
+  s.requires_arc        = true
+  s.platform            = :ios, "8.0"
+  s.pod_target_xcconfig = { "CLANG_CXX_LANGUAGE_STANDARD" => "c++14" }
+  s.header_dir          = 'RNGoogleSignin'
+  s.preserve_paths      = "package.json", "LICENSE", "LICENSE-CustomComponents", "PATENTS"
+
+  s.subspec 'Core' do |ss|
+    # ss.dependency      'Google/Signin'
+    ss.source_files  = "ios/**/*.{c,h,m,mm,S}"
+    ss.libraries     = "stdc++"
+  end
+end

--- a/RNGoogleSignin.podspec
+++ b/RNGoogleSignin.podspec
@@ -22,8 +22,8 @@ Pod::Spec.new do |s|
 
   s.subspec 'Core' do |ss|
     ss.dependency      'GoogleSignIn'
-    ss.dependency      'React'
-    ss.source_files  = "ios/**/*.{c,h,m,mm,S}"
+    ss.dependency      'React', '~> 0.39.2'
+    ss.source_files  = "ios/**/*.{h,m}"
     ss.libraries     = "stdc++"
   end
 end

--- a/ios/RNGoogleSignin.xcodeproj/project.pbxproj
+++ b/ios/RNGoogleSignin.xcodeproj/project.pbxproj
@@ -225,6 +225,7 @@
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
+					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";
@@ -242,6 +243,7 @@
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
+					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";

--- a/ios/RNGoogleSignin.xcodeproj/project.pbxproj
+++ b/ios/RNGoogleSignin.xcodeproj/project.pbxproj
@@ -223,11 +223,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/**",
 				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/../../../React/**",
-					"$(SRCROOT)/../../react-native/React/**",
-				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -241,11 +237,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/**",
 				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/../../../React/**",
-					"$(SRCROOT)/../../react-native/React/**",
-				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/ios/RNGoogleSignin.xcodeproj/project.pbxproj
+++ b/ios/RNGoogleSignin.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 				9FD3550E1D3E4A2900D06170 /* Sources */,
 				9FD3550F1D3E4A2900D06170 /* Frameworks */,
 				9FD355101D3E4A2900D06170 /* Copy Header */,
+				9F3884B41E32CEF40060427D /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -120,6 +121,22 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		9F3884B41E32CEF40060427D /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "echo SRCROOT $SRCROOT\necho PODS_ROOT $PODS_ROOT";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		9FD3550E1D3E4A2900D06170 /* Sources */ = {

--- a/ios/RNGoogleSignin/RNGoogleSignin.h
+++ b/ios/RNGoogleSignin/RNGoogleSignin.h
@@ -1,8 +1,8 @@
 #ifndef RN_GoogleSigning_h
 #define RN_GoogleSigning_h
 
-#import "RCTBridgeModule.h"
-#import "RCTConvert.h"
+#import <React/RCTBridgeModule.h>
+#import <React/RCTConvert.h>
 
 #import <GoogleSignIn/GoogleSignIn.h>
 

--- a/ios/RNGoogleSignin/RNGoogleSigninButtonManager.m
+++ b/ios/RNGoogleSignin/RNGoogleSigninButtonManager.m
@@ -1,5 +1,5 @@
 
-#import "RCTViewManager.h"
+#import <React/RCTViewManager.h>
 #import "RNGoogleSignIn.h"
 
 @interface RNGoogleSigninButtonManager : RCTViewManager


### PR DESCRIPTION
Fixes #53

I added a cocoapod podspec for this package.
It was also necessary to change the imports for the React native linking libraries. This is because my project uses the React.podspec file in the node_modules/react-native folder

Example Podfile using this (npm install react-native-google-signin is required first)
```
target 'Your Target' do
  pod 'RNGoogleSignin', :path => '../node_modules/react-native-google-signin',
  pod 'React', :path => '../node_modules/react-native',
    :subspecs => [
      'Core',
      'RCTLinkingIOS'
    ]
end
```

This will not work if you linked the react native files not using the 'React.podspec' file from there repo.

Possible fixes would be to somehow header alias the <React/Headerfile.h> to just Headerfile.h but I wasn't able to get a quick fix for that.

