### PR TITLE
Android - GoogleSignInOptions: fix an issue where the idToken is null if offlin…

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,6 +16,8 @@ allprojects {
 
 apply plugin: 'com.android.library'
 
+def DEFAULT_GOOGLE_PLAY_SERVICES_VERSION    = "+"
+
 android {
     compileSdkVersion 23
     buildToolsVersion "23.0.3"
@@ -29,15 +31,17 @@ android {
             abiFilters "armeabi-v7a", "x86"
         }
     }
-    
+
     lintOptions {
         abortOnError false
     }
 }
 
 dependencies {
+    def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : DEFAULT_GOOGLE_PLAY_SERVICES_VERSION
+
     compile fileTree(include: ['*.jar'], dir: 'libs')
     compile "com.android.support:appcompat-v7:23.0.1"
-    compile 'com.google.android.gms:play-services-auth:+'
+    compile "com.google.android.gms:play-services-auth:$googlePlayServicesVersion"
     compile "com.facebook.react:react-native:+"
 }

--- a/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
+++ b/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
@@ -288,9 +288,8 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
 
         GoogleSignInOptions.Builder googleSignInOptionsBuilder = new GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN).requestScopes(new Scope("email"), _scopes);
         if (webClientId != null && !webClientId.isEmpty()) {
-            if (!offlineAcess) {
-                googleSignInOptionsBuilder.requestIdToken(webClientId);
-            } else {
+            googleSignInOptionsBuilder.requestIdToken(webClientId);
+            if (offlineAcess) {
                 googleSignInOptionsBuilder.requestServerAuthCode(webClientId, forceConsentPrompt);
             }
         }

--- a/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninPackage.java
+++ b/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninPackage.java
@@ -22,7 +22,7 @@ public class RNGoogleSigninPackage implements ReactPackage {
         return modules;
     }
 
-    @Override
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
…eAccess is true.

Fixes https://github.com/devfd/react-native-google-signin/issues/222

The idToken is null if offlineAcess is true. With this change the idToken is always returned as long as a webClientId is provided in the configure method.