### PR TITLE
Change name of pod to install

### DIFF
--- a/ios-guide.md
+++ b/ios-guide.md
@@ -7,7 +7,7 @@ Includes Google Sign-In SDK v4.0.0
 #### Automatic
 
 - link the lib with `react-native link react-native-google-signin`
-- install the Google Signin SDK with [CocoaPods](https://cocoapods.org/) (add `pod 'Google/SignIn'` in your Podfile and run `pod install`)
+- install the Google Signin SDK with [CocoaPods](https://cocoapods.org/) (add `pod 'GoogleSignIn'` in your Podfile and run `pod install`)
 
 #### Manual
 


### PR DESCRIPTION
It seems like installing 'GoogleSignIn', rather than 'Google/SignIn', still works while pulling in fewer other dependencies.