### PR TITLE
Added requiresMainQueueSetup

### DIFF
--- a/ios/RNGoogleSignin/RNGoogleSignin.m
+++ b/ios/RNGoogleSignin/RNGoogleSignin.m
@@ -129,6 +129,11 @@ RCT_EXPORT_METHOD(revokeAccess)
                                       annotation:annotation];
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 #pragma mark - Internal Methods
 
 - (UIViewController *)topMostViewController {


### PR DESCRIPTION
Added requiresMainQueueSetup to prevent warning

Module RNGoogleSignin requires main queue setup since it overrides constantsToExport but doesn't implement `requiresMainQueueSetup. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.