### PR TITLE
Fix Search Paths / Argument List Too Long

### DIFF
--- a/ios/RNGoogleSignin.xcodeproj/project.pbxproj
+++ b/ios/RNGoogleSignin.xcodeproj/project.pbxproj
@@ -221,12 +221,12 @@
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/**",
+					"$(PROJECT_DIR)/../../../ios/Pods/GoogleSignIn/**",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../react-native/React/**",
-					"${SRCROOT}/../../../ios/**",
+					"$(PROJECT_DIR)/../../../ios/Pods/GoogleSignIn/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -239,12 +239,12 @@
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/**",
+					"$(PROJECT_DIR)/../../../ios/Pods/GoogleSignIn/**",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../react-native/React/**",
-					"${SRCROOT}/../../../ios/**",
+					"$(PROJECT_DIR)/../../../ios/Pods/GoogleSignIn/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
Very similar to https://github.com/xxsnakerxx/react-native-flurry-analytics/pull/22

Without this, my app does not compile as the `**` globbing on the entire project directory causes the Argument List Too Long error:

```
Argument list too long: recursive header expansion failed at /Users/nthompson/Documents/react-native/PROJECT_NAME/node_modules/react-native-google-signin/ios/../../../ios/build/Index/DataStore/v5/records/F4.
```