### PR TITLE
Tell rn to set up on main queue to suppress warning

### DIFF
--- a/ios/RNGoogleSignin/RNGoogleSignin.m
+++ b/ios/RNGoogleSignin/RNGoogleSignin.m
@@ -57,6 +57,11 @@ RCT_EXPORT_METHOD(revokeAccess)
   };
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 - (dispatch_queue_t)methodQueue
 {
     return dispatch_get_main_queue();


### PR DESCRIPTION
This would suppress the following warning.

> YellowBox.js:80 Module RNGoogleSignin requires main queue setup since it overrides `constantsToExport` but doesn't implement `requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.

ref: https://github.com/wix/react-native-navigation/issues/1982