### PR TITLE
add podspec

### DIFF
--- a/RNGoogleSignin.podspec
+++ b/RNGoogleSignin.podspec
@@ -1,0 +1,24 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name           = 'RNGoogleSignin'
+  s.version        = package['version']
+  s.summary        = package['description']
+  s.description    = package['description']
+  s.license        = package['license']
+  s.author         = package['author']
+  s.homepage       = package['homepage']
+  s.source         = { :git => 'https://github.com/react-native-community/react-native-google-signin.git', :tag => s.version }
+  
+
+  s.social_media_url   = "https://github.com/react-native-community/react-native-google-signin/pull/284/files"
+  s.requires_arc   = true
+  s.platform       = :ios, '8.0'
+  s.preserve_paths = 'LICENSE', 'README.md', 'package.json', 'index.js'
+
+  s.source_files  = "ios/RNGoogleSignin/*.{h,m}"
+  s.dependency 'GoogleSignIn'
+  s.dependency "React"
+end

--- a/RNGoogleSignin.podspec
+++ b/RNGoogleSignin.podspec
@@ -19,6 +19,5 @@ Pod::Spec.new do |s|
   s.preserve_paths = 'LICENSE', 'README.md', 'package.json', 'index.js'
 
   s.source_files  = "ios/RNGoogleSignin/*.{h,m}"
-  s.dependency 'GoogleSignIn'
   s.dependency "React"
 end


### PR DESCRIPTION
podspec for this package, now that is was moved to react-native-community. This closes several pending issues.


this can be added to podfile like this:

```
  pod "RNGoogleSignin", :path => '../node_modules/react-native-google-signin'

  pod 'Yoga', :path => '../node_modules/react-native/ReactCommon/yoga/Yoga.podspec'
  pod 'React', path: '../node_modules/react-native', :subspecs => [
    'Core',
    'RCTActionSheet',
    'RCTAnimation',
    'RCTGeolocation',
    'RCTImage',
    'RCTLinkingIOS',
    'RCTNetwork',
    'RCTSettings',
    'RCTText',
    'RCTVibration',
    'RCTWebSocket',
  ]
```
