### PR TITLE
Checking if promise unresolved before resolving

### DIFF
--- a/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
+++ b/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
@@ -118,14 +118,21 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
         }
         
         final ConnectionCallbacks connectionCallbacks = new ConnectionCallbacks() {
+            boolean promiseCalled = false;
             @Override
             public void onConnected(@Nullable Bundle bundle) {
-                promise.resolve(true);
+                if(!promiseCalled) {
+                    promise.resolve(true);
+                    promiseCalled = true;
+                }
             }
 
             @Override
             public void onConnectionSuspended(int i) {
-                promise.reject("CONNECT_ERROR", "CONNECT_ERROR");
+                if(!promiseCalled) {
+                    promise.reject("CONNECT_ERROR", "CONNECT_ERROR");
+                    promiseCalled = true;
+                }
             }
         };
 


### PR DESCRIPTION
Javascript promises are only resolved once.
However, according to googleApiClient docs, it retries to establish connection even after calling onConnectionSuspended once.
This throws an error as promise might have already been resolved or rejected once.