### PR TITLE
remove setup ios step

### DIFF
--- a/ios-guide.md
+++ b/ios-guide.md
@@ -42,37 +42,4 @@ Add the end of this step, your Xcode config should look like this:
 
 [![xcode config](https://github.com/apptailor/react-native-google-signin/raw/master/img/url-config.png)](#config)
 
-### Project setup
 
-Inside `AppDelegate.m`
-```objc
-// add this line before @implementation AppDelegate
-#import <RNGoogleSignin/RNGoogleSignin.h>
-
-// add this method before @end
-- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url
-  sourceApplication:(NSString *)sourceApplication annotation:(id)annotation {
-
-  return [RNGoogleSignin application:application openURL:url sourceApplication:sourceApplication annotation:annotation];
-}
-
-```
-
-Only one `openURL` method can be defined, so if you have multiple listeners which should be defined (for instance if you have both Google and Facebook OAuth), you must combine them into a single function like so:
-
-```objc
-- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url
-  sourceApplication:(NSString *)sourceApplication annotation:(id)annotation {
-
-  return [[FBSDKApplicationDelegate sharedInstance] application:application
-                                                        openURL:url
-                                              sourceApplication:sourceApplication
-                                                     annotation:annotation
-         ]
-         || [RNGoogleSignin application:application
-                                openURL:url
-                      sourceApplication:sourceApplication
-                             annotation:annotation
-            ];
-}
-```


### PR DESCRIPTION
Removing this set up step, because it's unnecessary and this step is causing issues with `'RNGoogleSignin/RNGoogleSignin.h'` not being found.

As proof of why it’s unnecessary to do this step, is the fact that rn-google-sign pckg is implementing the same methods as you can see here. https://github.com/react-native-community/react-native-google-signin/blob/master/ios/RNGoogleSignin/RNGoogleSignin.m#L169


Issue about `'RNGoogleSignin/RNGoogleSignin.h'` not being found.
https://github.com/react-native-community/react-native-google-signin/issues/428

Example app with google sign working.
https://github.com/AndreiCalazans/googleAuthTest