### PR TITLE
Update documentation to allow copy & paste without errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Example for default configuration. you get user email and basic profile info.
 import {GoogleSignin, GoogleSigninButton} from 'react-native-google-signin';
 
 GoogleSignin.configure({
-  iosClientId: <FROM DEVELOPER CONSOLE>, // only for iOS
+  iosClientId: '<FROM DEVELOPER CONSOLE>', // only for iOS
 })
 .then(() => {
   // you can now call currentUserAsync()
@@ -105,12 +105,12 @@ Example to access Google Drive both from the mobile application and from the bac
 ```js
 GoogleSignin.configure({
   scopes: ["https://www.googleapis.com/auth/drive.readonly"], // what API you want to access on behalf of the user, default is email and profile
-  iosClientId: <FROM DEVELOPER CONSOLE>, // only for iOS
-  webClientId: <FROM DEVELOPER CONSOLE>, // client ID of type WEB for your server (needed to verify user ID and offline access)
-  offlineAccess: true // if you want to access Google API on behalf of the user FROM YOUR SERVER
-  hostedDomain: '' // specifies a hosted domain restriction
-  forceConsentPrompt: true // [Android] if you want to show the authorization prompt at each login
-  accountName: '' // [Android] specifies an account name on the device that should be used
+  iosClientId: '<FROM DEVELOPER CONSOLE>', // only for iOS
+  webClientId: '<FROM DEVELOPER CONSOLE>', // client ID of type WEB for your server (needed to verify user ID and offline access)
+  offlineAccess: true, // if you want to access Google API on behalf of the user FROM YOUR SERVER
+  hostedDomain: '', // specifies a hosted domain restriction
+  forceConsentPrompt: true, // [Android] if you want to show the authorization prompt at each login
+  accountName: '', // [Android] specifies an account name on the device that should be used
 })
 .then(() => {
   // you can now call currentUserAsync()


### PR DESCRIPTION
Add missing commas in code examples. Add quotes around <placeholder> text to allow copy and paste without errors.