### PR TITLE
currentUserAsync to resolve to null on error

### DIFF
--- a/src/GoogleSignin.js
+++ b/src/GoogleSignin.js
@@ -47,7 +47,7 @@ class GoogleSignin {
     } catch (error) {
       this.signinIsInProcess = false;
 
-      return Promise.reject(error);
+      return Promise.resolve(null);
     }
   }
 


### PR DESCRIPTION
Ss seen [here](https://github.com/react-native-community/react-native-google-signin/blob/af706411b681b79bdf47fb27d7a5527f93b2f0a6/src/GoogleSignin.android.js#L101) and also as documented in readme, `currentUserAsync` should resolve to null if there is an error.

I previously introduced this breaking change and this PR removes the breakage.  We may wanna think if this is the right approach though.

This should be the last thing we need for a RC.