### PR TITLE
Utils.java: fix invalid EMAIL scope specification

### DIFF
--- a/android/src/main/java/co/apptailor/googlesignin/Utils.java
+++ b/android/src/main/java/co/apptailor/googlesignin/Utils.java
@@ -10,6 +10,7 @@ import com.facebook.react.bridge.WritableMap;
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount;
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions;
 import com.google.android.gms.common.api.Scope;
+import com.google.android.gms.common.Scopes;
 
 public class Utils {
 
@@ -55,7 +56,7 @@ public class Utils {
             final String hostedDomain
     ) {
         GoogleSignInOptions.Builder googleSignInOptionsBuilder = new GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
-                .requestScopes(GoogleSignInOptions.SCOPE_EMAIL, scopes);
+                .requestScopes(new Scope(Scopes.EMAIL), scopes);
         if (webClientId != null && !webClientId.isEmpty()) {
             googleSignInOptionsBuilder.requestIdToken(webClientId);
             if (offlineAcess) {


### PR DESCRIPTION
GoogleSignInOptions.SCOPE_EMAIL does not (or no longer?) exists. Its usage results in a build failure. Instead we need to use `com.google.android.gms.common.Scopes.EMAIL` and construct the SCOPE_EMAIL instance ourselves (as is consistent with the documentation at https://developers.google.com/android/guides/http-auth).

Fixes react-native-community/react-native-google-signin#439