### PR TITLE
changes in the library api

### DIFF
--- a/android/src/main/java/co/apptailor/googlesignin/PromiseWrapper.java
+++ b/android/src/main/java/co/apptailor/googlesignin/PromiseWrapper.java
@@ -1,0 +1,41 @@
+package co.apptailor.googlesignin;
+
+import android.util.Log;
+
+import com.facebook.react.bridge.Promise;
+
+import static co.apptailor.googlesignin.RNGoogleSigninModule.MODULE_NAME;
+
+public class PromiseWrapper {
+    private Promise _promise;
+
+
+    public boolean setPromiseWithInProgressCheck(Promise promise) {
+        boolean success = false;
+        if (_promise == null) {
+            _promise = promise;
+            success = true;
+        }
+        return success;
+    }
+
+    public void resolve(Object value) {
+        if (_promise == null) {
+            Log.w(MODULE_NAME, "cannot resolve promise because it's null");
+            return;
+        }
+
+        _promise.resolve(value);
+        _promise = null;
+    }
+
+    public void reject(String code, String message) {
+        if (_promise == null) {
+            Log.w(MODULE_NAME, "cannot reject promise because it's null");
+            return;
+        }
+
+        _promise.reject(code, message);
+        _promise = null;
+    }
+}

--- a/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
+++ b/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
@@ -204,14 +204,18 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
                 .addOnCompleteListener(new OnCompleteListener<Void>() {
                     @Override
                     public void onComplete(@NonNull Task<Void> task) {
-                        if (task.isSuccessful()) {
-                            promise.resolve(true);
-                        } else {
-                            int code = getExceptionCode(task);
-                            promise.reject(String.valueOf(code), GoogleSignInStatusCodes.getStatusCodeString(code));
-                        }
+                        handleSignOutOrRevokeAccessTask(task, promise);
                     }
                 });
+    }
+
+    private void handleSignOutOrRevokeAccessTask(@NonNull Task<Void> task, final Promise promise) {
+        if (task.isSuccessful()) {
+            promise.resolve(true);
+        } else {
+            int code = getExceptionCode(task);
+            promise.reject(String.valueOf(code), GoogleSignInStatusCodes.getStatusCodeString(code));
+        }
     }
 
     @ReactMethod
@@ -220,23 +224,12 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
             rejectWithNullClientError(promise);
             return;
         }
-        // we could use the `promise` variable directly as in `signOut` but we want the api to be consistent with iOS!
-        boolean wasPromiseSet = promiseWrapper.setPromiseWithInProgressCheck(promise);
-        if (!wasPromiseSet) {
-            rejectWithAsyncOperationStillInProgress(promise);
-            return;
-        }
 
         _apiClient.revokeAccess()
                 .addOnCompleteListener(new OnCompleteListener<Void>() {
                     @Override
                     public void onComplete(@NonNull Task<Void> task) {
-                        if (task.isSuccessful()) {
-                            promiseWrapper.resolve(true);
-                        } else {
-                            int code = getExceptionCode(task);
-                            promiseWrapper.reject(String.valueOf(code), GoogleSignInStatusCodes.getStatusCodeString(code));
-                        }
+                        handleSignOutOrRevokeAccessTask(task, promise);
                     }
                 });
     }

--- a/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
+++ b/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
@@ -27,6 +27,7 @@ import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.gms.common.SignInButton;
 import com.google.android.gms.common.api.ApiException;
+import com.google.android.gms.common.api.CommonStatusCodes;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
 
@@ -222,11 +223,9 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
         if (task.isSuccessful()) {
             resolve(true);
         } else {
-            Exception e = task.getException();
-            // the message may contain a number code that you can use with GoogleSignInStatusCodes.getStatusCodeString
-            // but generally won't be very readable
-            String message = e != null ? e.getLocalizedMessage() : "unknown error";
-            reject("0", message);
+            ApiException e = (ApiException) task.getException();
+            int code = e != null ? e.getStatusCode() : CommonStatusCodes.INTERNAL_ERROR;
+            reject(String.valueOf(code), GoogleSignInStatusCodes.getStatusCodeString(code));
         }
     }
 

--- a/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
+++ b/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
@@ -223,8 +223,14 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
         if (task.isSuccessful()) {
             resolve(true);
         } else {
-            ApiException e = (ApiException) task.getException();
-            int code = e != null ? e.getStatusCode() : CommonStatusCodes.INTERNAL_ERROR;
+            Exception e = task.getException();
+
+            int code = CommonStatusCodes.INTERNAL_ERROR;
+            if (e instanceof ApiException) {
+                ApiException exception = (ApiException) e;
+                code = exception.getStatusCode();
+            }
+
             reject(String.valueOf(code), GoogleSignInStatusCodes.getStatusCodeString(code));
         }
     }

--- a/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
+++ b/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
@@ -57,17 +57,6 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
         reactContext.addActivityEventListener(new RNGoogleSigninActivityEventListener());
     }
 
-    private class RNGoogleSigninActivityEventListener extends BaseActivityEventListener {
-        @Override
-        public void onActivityResult(Activity activity, final int requestCode, final int resultCode, final Intent intent) {
-            if (requestCode == RC_SIGN_IN) {
-                // The Task returned from this call is always completed, no need to attach a listener.
-                Task<GoogleSignInAccount> task = GoogleSignIn.getSignedInAccountFromIntent(intent);
-                handleSignInTaskResult(task);
-            }
-        }
-    }
-
     @Override
     public Map<String, Object> getConstants() {
         final Map<String, Object> constants = new HashMap<>();
@@ -184,6 +173,17 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
         });
     }
 
+    private class RNGoogleSigninActivityEventListener extends BaseActivityEventListener {
+        @Override
+        public void onActivityResult(Activity activity, final int requestCode, final int resultCode, final Intent intent) {
+            if (requestCode == RC_SIGN_IN) {
+                // The Task returned from this call is always completed, no need to attach a listener.
+                Task<GoogleSignInAccount> task = GoogleSignIn.getSignedInAccountFromIntent(intent);
+                handleSignInTaskResult(task);
+            }
+        }
+    }
+
     @ReactMethod
     public void signOut(final Promise promise) {
         if (_apiClient == null) {
@@ -208,6 +208,7 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
             return;
         }
         _signinPromise = promise;
+
         _apiClient.revokeAccess()
                 .addOnCompleteListener(new OnCompleteListener<Void>() {
                     @Override
@@ -221,7 +222,11 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
         if (task.isSuccessful()) {
             resolve(true);
         } else {
-            reject("0", "unknown error");
+            Exception e = task.getException();
+            // the message may contain a number code that you can use with GoogleSignInStatusCodes.getStatusCodeString
+            // but generally won't be very readable
+            String message = e != null ? e.getLocalizedMessage() : "unknown error";
+            reject("0", message);
         }
     }
 

--- a/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
+++ b/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
@@ -27,6 +27,7 @@ import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.gms.common.SignInButton;
 import com.google.android.gms.common.api.ApiException;
+import com.google.android.gms.common.api.CommonStatusCodes;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
 
@@ -46,6 +47,8 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
 
     public static final int RC_SIGN_IN = 9001;
     public static final String MODULE_NAME = "RNGoogleSignin";
+    public static final String ASYNC_OP_IN_PROGRESS = "ASYNC_OP_IN_PROGRESS";
+
     private PromiseWrapper promiseWrapper;
 
     @Override
@@ -68,6 +71,9 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
         constants.put("BUTTON_COLOR_AUTO", SignInButton.COLOR_AUTO);
         constants.put("BUTTON_COLOR_LIGHT", SignInButton.COLOR_LIGHT);
         constants.put("BUTTON_COLOR_DARK", SignInButton.COLOR_DARK);
+        // note - google does not give a specific code for cancelled action :/
+        constants.put("SIGNIN_CANCELLED", String.valueOf(CommonStatusCodes.ERROR));
+        constants.put("ASYNC_OP_IN_PROGRESS", ASYNC_OP_IN_PROGRESS);
         return constants;
     }
 
@@ -252,7 +258,7 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
     }
 
     private void rejectWithAsyncOperationStillInProgress(Promise promise) {
-        promise.reject("ASYNC_OP_IN_PROGRESS", "cannot set promise - some async operation is still in progress");
+        promise.reject(ASYNC_OP_IN_PROGRESS, "cannot set promise - some async operation is still in progress");
     }
 
 }

--- a/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
+++ b/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
@@ -72,8 +72,8 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
         constants.put("BUTTON_COLOR_LIGHT", SignInButton.COLOR_LIGHT);
         constants.put("BUTTON_COLOR_DARK", SignInButton.COLOR_DARK);
         // note - google does not give a specific code for cancelled action :/
-        constants.put("SIGNIN_CANCELLED", String.valueOf(CommonStatusCodes.ERROR));
-        constants.put("ASYNC_OP_IN_PROGRESS", ASYNC_OP_IN_PROGRESS);
+        constants.put("CANCEL", String.valueOf(CommonStatusCodes.ERROR));
+        constants.put("IN_PROGRESS", ASYNC_OP_IN_PROGRESS);
         return constants;
     }
 

--- a/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
+++ b/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
@@ -152,7 +152,7 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void currentUserAsync(Promise promise) {
+    public void getCurrentUser(Promise promise) {
         if (_apiClient == null) {
             rejectWithNullClientError();
             return;

--- a/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
+++ b/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
@@ -71,8 +71,7 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
         constants.put("BUTTON_COLOR_AUTO", SignInButton.COLOR_AUTO);
         constants.put("BUTTON_COLOR_LIGHT", SignInButton.COLOR_LIGHT);
         constants.put("BUTTON_COLOR_DARK", SignInButton.COLOR_DARK);
-        // note - google does not give a specific code for cancelled action :/
-        constants.put("CANCEL", String.valueOf(CommonStatusCodes.ERROR));
+        constants.put("CANCEL", String.valueOf(GoogleSignInStatusCodes.SIGN_IN_CANCELLED));
         constants.put("IN_PROGRESS", ASYNC_OP_IN_PROGRESS);
         return constants;
     }

--- a/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
+++ b/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
@@ -27,7 +27,6 @@ import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.gms.common.SignInButton;
 import com.google.android.gms.common.api.ApiException;
-import com.google.android.gms.common.api.CommonStatusCodes;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
 
@@ -71,7 +70,7 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
         constants.put("BUTTON_COLOR_AUTO", SignInButton.COLOR_AUTO);
         constants.put("BUTTON_COLOR_LIGHT", SignInButton.COLOR_LIGHT);
         constants.put("BUTTON_COLOR_DARK", SignInButton.COLOR_DARK);
-        constants.put("CANCEL", String.valueOf(GoogleSignInStatusCodes.SIGN_IN_CANCELLED));
+        constants.put("SIGN_IN_CANCELLED", String.valueOf(GoogleSignInStatusCodes.SIGN_IN_CANCELLED));
         constants.put("IN_PROGRESS", ASYNC_OP_IN_PROGRESS);
         return constants;
     }

--- a/android/src/main/java/co/apptailor/googlesignin/Utils.java
+++ b/android/src/main/java/co/apptailor/googlesignin/Utils.java
@@ -26,6 +26,14 @@ public class Utils {
     static WritableMap getUserProperties(@NonNull GoogleSignInAccount acct) {
         Uri photoUrl = acct.getPhotoUrl();
 
+        WritableMap user = Arguments.createMap();
+        user.putString("id", acct.getId());
+        user.putString("name", acct.getDisplayName());
+        user.putString("givenName", acct.getGivenName());
+        user.putString("familyName", acct.getFamilyName());
+        user.putString("email", acct.getEmail());
+        user.putString("photo", photoUrl != null ? photoUrl.toString() : null);
+
         WritableArray scopes = Arguments.createArray();
         for(Scope scope : acct.getGrantedScopes()) {
             String scopeString = scope.toString();
@@ -35,15 +43,13 @@ public class Utils {
         }
 
         WritableMap params = Arguments.createMap();
-        params.putString("id", acct.getId());
-        params.putString("name", acct.getDisplayName());
-        params.putString("givenName", acct.getGivenName());
-        params.putString("familyName", acct.getFamilyName());
-        params.putString("email", acct.getEmail());
-        params.putString("photo", photoUrl != null ? photoUrl.toString() : null);
+        params.putString("type", "success");
         params.putString("idToken", acct.getIdToken());
         params.putString("serverAuthCode", acct.getServerAuthCode());
+        params.putString("accessToken", null);
+        params.putString("accessTokenExpirationDate", null);
         params.putArray("scopes", scopes);
+        params.putMap("user", user);
         return params;
     }
 

--- a/android/src/main/java/co/apptailor/googlesignin/Utils.java
+++ b/android/src/main/java/co/apptailor/googlesignin/Utils.java
@@ -37,6 +37,13 @@ public class Utils {
         user.putString("email", acct.getEmail());
         user.putString("photo", photoUrl != null ? photoUrl.toString() : null);
 
+        WritableMap params = Arguments.createMap();
+        params.putMap("user", user);
+        params.putString("idToken", acct.getIdToken());
+        params.putString("serverAuthCode", acct.getServerAuthCode());
+        params.putString("accessToken", null);
+        params.putString("accessTokenExpirationDate", null);
+
         WritableArray scopes = Arguments.createArray();
         for(Scope scope : acct.getGrantedScopes()) {
             String scopeString = scope.toString();
@@ -44,14 +51,7 @@ public class Utils {
                 scopes.pushString(scopeString);
             }
         }
-
-        WritableMap params = Arguments.createMap();
-        params.putString("idToken", acct.getIdToken());
-        params.putString("serverAuthCode", acct.getServerAuthCode());
-        params.putString("accessToken", null);
-        params.putString("accessTokenExpirationDate", null);
         params.putArray("scopes", scopes);
-        params.putMap("user", user);
         return params;
     }
 
@@ -95,11 +95,10 @@ public class Utils {
     public static int getExceptionCode(@NonNull Task<Void> task) {
         Exception e = task.getException();
 
-        int code = CommonStatusCodes.INTERNAL_ERROR;
         if (e instanceof ApiException) {
             ApiException exception = (ApiException) e;
-            code = exception.getStatusCode();
+            return exception.getStatusCode();
         }
-        return code;
+        return CommonStatusCodes.INTERNAL_ERROR;
     }
 }

--- a/android/src/main/java/co/apptailor/googlesignin/Utils.java
+++ b/android/src/main/java/co/apptailor/googlesignin/Utils.java
@@ -9,8 +9,11 @@ import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount;
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions;
+import com.google.android.gms.common.api.ApiException;
+import com.google.android.gms.common.api.CommonStatusCodes;
 import com.google.android.gms.common.api.Scope;
 import com.google.android.gms.common.Scopes;
+import com.google.android.gms.tasks.Task;
 
 public class Utils {
 
@@ -87,5 +90,16 @@ public class Utils {
             _scopes[i] = new Scope(scopeName);
         }
         return _scopes;
+    }
+
+    public static int getExceptionCode(@NonNull Task<Void> task) {
+        Exception e = task.getException();
+
+        int code = CommonStatusCodes.INTERNAL_ERROR;
+        if (e instanceof ApiException) {
+            ApiException exception = (ApiException) e;
+            code = exception.getStatusCode();
+        }
+        return code;
     }
 }

--- a/android/src/main/java/co/apptailor/googlesignin/Utils.java
+++ b/android/src/main/java/co/apptailor/googlesignin/Utils.java
@@ -43,7 +43,6 @@ public class Utils {
         }
 
         WritableMap params = Arguments.createMap();
-        params.putString("type", "success");
         params.putString("idToken", acct.getIdToken());
         params.putString("serverAuthCode", acct.getServerAuthCode());
         params.putString("accessToken", null);

--- a/example/index.js
+++ b/example/index.js
@@ -104,7 +104,7 @@ class GoogleSigninSampleApp extends Component {
       const userInfo = await GoogleSignin.signIn();
       this.setState({ userInfo, error: null });
     } catch (error) {
-      if (error.code === statusCodes.CANCEL) {
+      if (error.code === statusCodes.SIGN_IN_CANCELLED) {
         // sign in was cancelled
         alert('cancelled');
       } else if (error.code === statusCodes.IN_PROGRESS) {

--- a/example/index.js
+++ b/example/index.js
@@ -104,10 +104,10 @@ class GoogleSigninSampleApp extends Component {
       const userInfo = await GoogleSignin.signIn();
       this.setState({ userInfo, error: null });
     } catch (error) {
-      if (error.code === statusCodes.SIGNIN_CANCELLED) {
+      if (error.code === statusCodes.CANCEL) {
         // sign in was cancelled
         alert('cancelled');
-      } else if (error.code === statusCodes.ASYNC_OP_IN_PROGRESS) {
+      } else if (error.code === statusCodes.IN_PROGRESS) {
         // operation in progress already
         alert('in progress');
       } else {

--- a/example/index.js
+++ b/example/index.js
@@ -9,11 +9,7 @@ import {
   Alert,
 } from 'react-native';
 
-import {
-  GoogleSignin,
-  GoogleSigninButton,
-  doesErrorNeedToBeHandled,
-} from 'react-native-google-signin';
+import { GoogleSignin, GoogleSigninButton, statusCodes } from 'react-native-google-signin';
 import config from './config';
 
 class GoogleSigninSampleApp extends Component {
@@ -108,7 +104,13 @@ class GoogleSigninSampleApp extends Component {
       const userInfo = await GoogleSignin.signIn();
       this.setState({ userInfo, error: null });
     } catch (error) {
-      if (doesErrorNeedToBeHandled(error)) {
+      if (error.code === statusCodes.SIGNIN_CANCELLED) {
+        // sign in was cancelled
+        alert('cancelled');
+      } else if (error.code === statusCodes.ASYNC_OP_IN_PROGRESS) {
+        // operation in progress already
+        alert('in progress');
+      } else {
         Alert.alert('Something went wrong', error.toString());
         this.setState({
           error,

--- a/example/index.js
+++ b/example/index.js
@@ -44,7 +44,7 @@ class GoogleSigninSampleApp extends Component {
 
   async _getCurrentUser() {
     try {
-      const user = await GoogleSignin.getCurrentUser(configObject);
+      const user = await GoogleSignin.signInSilently(configObject);
       this.setState({ user, error: null });
     } catch (error) {
       this.setState({

--- a/example/index.js
+++ b/example/index.js
@@ -60,7 +60,7 @@ class GoogleSigninSampleApp extends Component {
   }
 
   render() {
-    const { userInfo, error } = this.state;
+    const { userInfo } = this.state;
     if (!userInfo) {
       return (
         <View style={styles.container}>
@@ -70,11 +70,7 @@ class GoogleSigninSampleApp extends Component {
             color={GoogleSigninButton.Color.Auto}
             onPress={this._signIn}
           />
-          {error && (
-            <Text>
-              {error.toString()} code: {error.code}
-            </Text>
-          )}
+          {this.renderError()}
         </View>
       );
     } else {
@@ -86,13 +82,25 @@ class GoogleSigninSampleApp extends Component {
           <Text>Your email is: {userInfo.user.email}</Text>
 
           <TouchableOpacity onPress={this._signOut}>
-            <View style={{ marginTop: 50 }}>
+            <View style={{ marginTop: 50, padding: 20 }}>
               <Text>Log out</Text>
             </View>
           </TouchableOpacity>
+          {this.renderError()}
         </View>
       );
     }
+  }
+
+  renderError() {
+    const { error } = this.state;
+    return (
+      !!error && (
+        <Text>
+          {error.toString()} code: {error.code}
+        </Text>
+      )
+    );
   }
 
   _signIn = async () => {
@@ -114,7 +122,7 @@ class GoogleSigninSampleApp extends Component {
       await GoogleSignin.revokeAccess();
       await GoogleSignin.signOut();
 
-      this.setState({ userInfo: null });
+      this.setState({ userInfo: null, error: null });
     } catch (error) {
       this.setState({
         error,

--- a/example/index.js
+++ b/example/index.js
@@ -12,7 +12,7 @@ import {
 import { GoogleSignin, GoogleSigninButton, isSigninCancellation } from 'react-native-google-signin';
 import config from './config';
 
-const configPlatform = {
+const configPerPlatform = {
   ...Platform.select({
     ios: {
       iosClientId: config.iosClientId,
@@ -24,8 +24,8 @@ const configPlatform = {
 };
 
 const configObject = {
-  ..configPerPlatform,
-  webClientId: configPerPlatformtId,
+  ...configPerPlatform,
+  webClientId: config.webClientId,
   offlineAccess: false,
 };
 
@@ -44,7 +44,7 @@ class GoogleSigninSampleApp extends Component {
 
   async _getCurrentUser() {
     try {
-      const user = await GoogleSignin.getCurrentUser();
+      const user = await GoogleSignin.getCurrentUser(configObject);
       this.setState({ user, error: null });
     } catch (error) {
       this.setState({
@@ -75,9 +75,9 @@ class GoogleSigninSampleApp extends Component {
       return (
         <View style={styles.container}>
           <Text style={{ fontSize: 18, fontWeight: 'bold', marginBottom: 20 }}>
-            Welcome {user.name}
+            Welcome {user.user.name}
           </Text>
-          <Text>Your email is: {user.email}</Text>
+          <Text>Your email is: {user.user.email}</Text>
 
           <TouchableOpacity onPress={this._signOut}>
             <View style={{ marginTop: 50 }}>
@@ -98,10 +98,6 @@ class GoogleSigninSampleApp extends Component {
         Alert.alert('Something went wrong', error.toString());
         this.setState({
           error,
-        });
-      } else {
-        this.setState({
-          error: 'user cancelled the login flow',
         });
       }
     }

--- a/example/index.js
+++ b/example/index.js
@@ -20,7 +20,7 @@ class GoogleSigninSampleApp extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      user: null,
+      userInfo: null,
       error: null,
     };
   }
@@ -50,8 +50,8 @@ class GoogleSigninSampleApp extends Component {
 
   async _getCurrentUser() {
     try {
-      const user = await GoogleSignin.signInSilently();
-      this.setState({ user, error: null });
+      const userInfo = await GoogleSignin.signInSilently();
+      this.setState({ userInfo, error: null });
     } catch (error) {
       this.setState({
         error,
@@ -60,8 +60,8 @@ class GoogleSigninSampleApp extends Component {
   }
 
   render() {
-    const { user, error } = this.state;
-    if (!user) {
+    const { userInfo, error } = this.state;
+    if (!userInfo) {
       return (
         <View style={styles.container}>
           <GoogleSigninButton
@@ -81,9 +81,9 @@ class GoogleSigninSampleApp extends Component {
       return (
         <View style={styles.container}>
           <Text style={{ fontSize: 18, fontWeight: 'bold', marginBottom: 20 }}>
-            Welcome {user.user.name}
+            Welcome {userInfo.user.name}
           </Text>
-          <Text>Your email is: {user.user.email}</Text>
+          <Text>Your email is: {userInfo.user.email}</Text>
 
           <TouchableOpacity onPress={this._signOut}>
             <View style={{ marginTop: 50 }}>
@@ -97,8 +97,8 @@ class GoogleSigninSampleApp extends Component {
 
   _signIn = async () => {
     try {
-      const user = await GoogleSignin.signIn();
-      this.setState({ user, error: null });
+      const userInfo = await GoogleSignin.signIn();
+      this.setState({ userInfo, error: null });
     } catch (error) {
       if (doesErrorNeedToBeHandled(error)) {
         Alert.alert('Something went wrong', error.toString());
@@ -114,7 +114,7 @@ class GoogleSigninSampleApp extends Component {
       await GoogleSignin.revokeAccess();
       await GoogleSignin.signOut();
 
-      this.setState({ user: null });
+      this.setState({ userInfo: null });
     } catch (error) {
       this.setState({
         error,

--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
-export { GoogleSigninSingleton as GoogleSignin } from './src/GoogleSignin';
+export { GoogleSigninSingleton as GoogleSignin, isSigninCancellation } from './src/GoogleSignin';
 export { GoogleSigninButton } from './src/GoogleSigninButton';

--- a/index.js
+++ b/index.js
@@ -1,5 +1,2 @@
-export {
-  GoogleSigninSingleton as GoogleSignin,
-  doesErrorNeedToBeHandled,
-} from './src/GoogleSignin';
+export { GoogleSigninSingleton as GoogleSignin, statusCodes } from './src/GoogleSignin';
 export { GoogleSigninButton } from './src/GoogleSigninButton';

--- a/index.js
+++ b/index.js
@@ -1,2 +1,5 @@
-export { GoogleSigninSingleton as GoogleSignin, isSigninCancellation } from './src/GoogleSignin';
+export {
+  GoogleSigninSingleton as GoogleSignin,
+  doesErrorNeedToBeHandled,
+} from './src/GoogleSignin';
 export { GoogleSigninButton } from './src/GoogleSigninButton';

--- a/ios/RNGoogleSignin.xcodeproj/project.pbxproj
+++ b/ios/RNGoogleSignin.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		04A616CC20B85BA800B435C6 /* RNGoogleSignInButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 04A616CB20B85BA800B435C6 /* RNGoogleSignInButton.m */; };
+		79384FBB2114DF7400F3D9BD /* PromiseWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 79384FBA2114DF7400F3D9BD /* PromiseWrapper.m */; };
 		9FD355211D3E4ACC00D06170 /* RNGoogleSignin.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FD3551F1D3E4ACC00D06170 /* RNGoogleSignin.m */; };
 		9FD355221D3E4ACC00D06170 /* RNGoogleSigninButtonManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FD355201D3E4ACC00D06170 /* RNGoogleSigninButtonManager.m */; };
 		9FD355331D3E4D3600D06170 /* RNGoogleSignin.h in Copy Header */ = {isa = PBXBuildFile; fileRef = 9FD3551E1D3E4ACC00D06170 /* RNGoogleSignin.h */; };
@@ -30,6 +31,8 @@
 /* Begin PBXFileReference section */
 		04A616CA20B85BA800B435C6 /* RNGoogleSignInButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNGoogleSignInButton.h; sourceTree = "<group>"; };
 		04A616CB20B85BA800B435C6 /* RNGoogleSignInButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNGoogleSignInButton.m; sourceTree = "<group>"; };
+		79384FB92114DF7400F3D9BD /* PromiseWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PromiseWrapper.h; sourceTree = "<group>"; };
+		79384FBA2114DF7400F3D9BD /* PromiseWrapper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PromiseWrapper.m; sourceTree = "<group>"; };
 		9FD355121D3E4A2900D06170 /* libRNGoogleSignin.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNGoogleSignin.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		9FD3551E1D3E4ACC00D06170 /* RNGoogleSignin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNGoogleSignin.h; sourceTree = "<group>"; };
 		9FD3551F1D3E4ACC00D06170 /* RNGoogleSignin.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNGoogleSignin.m; sourceTree = "<group>"; };
@@ -66,6 +69,8 @@
 		9FD355141D3E4A2900D06170 /* RNGoogleSignin */ = {
 			isa = PBXGroup;
 			children = (
+				79384FB92114DF7400F3D9BD /* PromiseWrapper.h */,
+				79384FBA2114DF7400F3D9BD /* PromiseWrapper.m */,
 				04A616CA20B85BA800B435C6 /* RNGoogleSignInButton.h */,
 				04A616CB20B85BA800B435C6 /* RNGoogleSignInButton.m */,
 				9FD3551E1D3E4ACC00D06170 /* RNGoogleSignin.h */,
@@ -134,6 +139,7 @@
 				04A616CC20B85BA800B435C6 /* RNGoogleSignInButton.m in Sources */,
 				9FD355221D3E4ACC00D06170 /* RNGoogleSigninButtonManager.m in Sources */,
 				9FD355211D3E4ACC00D06170 /* RNGoogleSignin.m in Sources */,
+				79384FBB2114DF7400F3D9BD /* PromiseWrapper.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/RNGoogleSignin/PromiseWrapper.h
+++ b/ios/RNGoogleSignin/PromiseWrapper.h
@@ -1,0 +1,21 @@
+//
+//  PromiseWrapper.h
+//  RNGoogleSignin
+//
+//  Created by Vojtech Novak on 26/07/2018.
+//  Copyright © 2018 Apptailor. All rights reserved.
+//
+
+#ifndef PromiseWrapper_h
+#define PromiseWrapper_h
+#import <React/RCTBridgeModule.h>
+
+@interface PromiseWrapper : NSObject
+
+-(BOOL) setPromiseWithInProgressCheck:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject;
+-(void) resolve: (id) result;
+-(void) reject:(NSString *)message withError:(NSError *)error;
+
+@end
+
+#endif /* PromiseWrapper_h */

--- a/ios/RNGoogleSignin/PromiseWrapper.m
+++ b/ios/RNGoogleSignin/PromiseWrapper.m
@@ -1,0 +1,57 @@
+//
+//  PromiseWrapper.m
+//  RNGoogleSignin
+//
+//  Created by Vojtech Novak on 26/07/2018.
+//  Copyright © 2018 Apptailor. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "PromiseWrapper.h"
+
+
+@interface PromiseWrapper ()
+
+@property (nonatomic, strong) RCTPromiseResolveBlock promiseResolve;
+@property (nonatomic, strong) RCTPromiseRejectBlock promiseReject;
+
+@end
+
+@implementation PromiseWrapper
+
+-(BOOL) setPromiseWithInProgressCheck: (RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject {
+  BOOL success = NO;
+  if (!self.promiseResolve) {
+    self.promiseResolve = resolve;
+    self.promiseReject = reject;
+    success = YES;
+  }
+  return success;
+}
+
+-(void) resolve: (id) result {
+  if (self.promiseResolve == nil) {
+    NSLog(@"cannot resolve promise because it's null");
+    return;
+  }
+  self.promiseResolve(result);
+  self.promiseResolve = nil;
+  self.promiseReject = nil;
+}
+
+-(void) reject:(NSString *)message withError:(NSError *)error {
+  if (self.promiseResolve == nil) {
+    NSLog(@"cannot resolve promise because it's null");
+    return;
+  }
+  NSString* errorCode = [NSString stringWithFormat:@"%ld", error.code];
+  NSString* errorMessage = [NSString stringWithFormat:@"RNGoogleSignInError: %@, %@", message, error.description];
+  
+  self.promiseReject(errorCode, errorMessage, error);
+  
+  self.promiseResolve = nil;
+  self.promiseReject = nil;
+}
+
+
+@end

--- a/ios/RNGoogleSignin/RNGoogleSignin.h
+++ b/ios/RNGoogleSignin/RNGoogleSignin.h
@@ -7,6 +7,7 @@
 
 #import <GoogleSignIn/GoogleSignIn.h>
 
+
 @interface RNGoogleSignin : NSObject<RCTBridgeModule, GIDSignInDelegate, GIDSignInUIDelegate>
 
 + (BOOL)application:(UIApplication *)application openURL:(NSURL *)url
@@ -33,7 +34,6 @@ RCT_ENUM_CONVERTER(GIDSignInButtonColorScheme, (@{
                                                   }), kGIDSignInButtonColorSchemeDark, integerValue)
 
 @end
-
 
 
 #endif

--- a/ios/RNGoogleSignin/RNGoogleSignin.m
+++ b/ios/RNGoogleSignin/RNGoogleSignin.m
@@ -120,28 +120,33 @@ RCT_REMAP_METHOD(revokeAccess,
         }
       return;
     }
-
+    
     NSURL *imageURL;
-
+    
     if (user.profile.hasImage)
     {
-      imageURL = [user.profile imageURLWithDimension:120];
+        imageURL = [user.profile imageURLWithDimension:120];
     }
 
-    NSDictionary *body = @{
+    NSDictionary *userInfo = @{
+                           @"id": user.userID,
                            @"name": user.profile.name,
                            @"givenName": user.profile.givenName,
                            @"familyName": user.profile.familyName,
-                           @"id": user.userID,
                            @"photo": imageURL ? imageURL.absoluteString : [NSNull null],
-                           @"email": user.profile.email,
+                           @"email": user.profile.email
+                           };
+    
+    NSDictionary *params = @{
+                           @"type": @"success",
                            @"idToken": user.authentication.idToken,
-                           @"accessToken": user.authentication.accessToken,
                            @"serverAuthCode": user.serverAuthCode ? user.serverAuthCode : [NSNull null],
-                           @"accessTokenExpirationDate": [NSNumber numberWithDouble:user.authentication.accessTokenExpirationDate.timeIntervalSinceNow]
+                           @"accessToken": user.authentication.accessToken,
+                           @"accessTokenExpirationDate": [NSNumber numberWithDouble:user.authentication.accessTokenExpirationDate.timeIntervalSinceNow],
+                           @"user": userInfo
                            };
 
-    self.promiseResolve(body);
+    self.promiseResolve(params);
 }
 
 - (void)signIn:(GIDSignIn *)signIn didDisconnectWithUser:(GIDGoogleUser *)user withError:(NSError *)error {

--- a/ios/RNGoogleSignin/RNGoogleSignin.m
+++ b/ios/RNGoogleSignin/RNGoogleSignin.m
@@ -15,7 +15,6 @@ RCT_EXPORT_METHOD(configure:(NSDictionary *)options
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
-  GIDGoogleUser *currentUser = [GIDSignIn sharedInstance].currentUser;
   [GIDSignIn sharedInstance].delegate = self;
   [GIDSignIn sharedInstance].uiDelegate = self;
   [GIDSignIn sharedInstance].scopes = options[@"scopes"];

--- a/ios/RNGoogleSignin/RNGoogleSignin.m
+++ b/ios/RNGoogleSignin/RNGoogleSignin.m
@@ -15,6 +15,16 @@ RCT_EXPORT_METHOD(configure:(NSDictionary *)options
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
+  // TODO we need to be smarter than this
+  BOOL isConfigurationNeeded = [GIDSignIn sharedInstance].delegate != self;
+  if (isConfigurationNeeded) {
+    [self configureGoogleSingInInstance: options];
+  }
+  
+  resolve(@YES);
+}
+
+- (void) configureGoogleSingInInstance: (NSDictionary *)options {
   [GIDSignIn sharedInstance].delegate = self;
   [GIDSignIn sharedInstance].uiDelegate = self;
   [GIDSignIn sharedInstance].scopes = options[@"scopes"];
@@ -27,11 +37,9 @@ RCT_EXPORT_METHOD(configure:(NSDictionary *)options
   if (options[@"webClientId"]) {
     [GIDSignIn sharedInstance].serverClientID = options[@"webClientId"];
   }
-
-  resolve(@YES);
 }
 
-RCT_REMAP_METHOD(currentUserAsync,
+RCT_REMAP_METHOD(getCurrentUser,
                  currentUserAsyncResolve:(RCTPromiseResolveBlock)resolve
                 currentUserAsyncReject:(RCTPromiseRejectBlock)reject)
 {

--- a/ios/RNGoogleSignin/RNGoogleSignin.m
+++ b/ios/RNGoogleSignin/RNGoogleSignin.m
@@ -22,7 +22,7 @@ static NSString *const ASYNC_OP_IN_PROGRESS = @"ASYNC_OP_IN_PROGRESS";
            @"BUTTON_SIZE_WIDE": @(kGIDSignInButtonStyleWide),
            @"BUTTON_COLOR_LIGHT": @(kGIDSignInButtonColorSchemeLight),
            @"BUTTON_COLOR_DARK": @(kGIDSignInButtonColorSchemeDark),
-           @"CANCEL": [@(kGIDSignInErrorCodeCanceled) stringValue],
+           @"SIGN_IN_CANCELLED": [@(kGIDSignInErrorCodeCanceled) stringValue],
            @"IN_PROGRESS": ASYNC_OP_IN_PROGRESS
            };
 }

--- a/ios/RNGoogleSignin/RNGoogleSignin.m
+++ b/ios/RNGoogleSignin/RNGoogleSignin.m
@@ -15,16 +15,7 @@ RCT_EXPORT_METHOD(configure:(NSDictionary *)options
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
-  // TODO we need to be smarter than this
-  BOOL isConfigurationNeeded = [GIDSignIn sharedInstance].delegate != self;
-  if (isConfigurationNeeded) {
-    [self configureGoogleSingInInstance: options];
-  }
-  
-  resolve(@YES);
-}
-
-- (void) configureGoogleSingInInstance: (NSDictionary *)options {
+  GIDGoogleUser *currentUser = [GIDSignIn sharedInstance].currentUser;
   [GIDSignIn sharedInstance].delegate = self;
   [GIDSignIn sharedInstance].uiDelegate = self;
   [GIDSignIn sharedInstance].scopes = options[@"scopes"];
@@ -37,9 +28,11 @@ RCT_EXPORT_METHOD(configure:(NSDictionary *)options
   if (options[@"webClientId"]) {
     [GIDSignIn sharedInstance].serverClientID = options[@"webClientId"];
   }
+  
+  resolve(@YES);
 }
 
-RCT_REMAP_METHOD(getCurrentUser,
+RCT_REMAP_METHOD(signInSilently,
                  currentUserAsyncResolve:(RCTPromiseResolveBlock)resolve
                 currentUserAsyncReject:(RCTPromiseRejectBlock)reject)
 {

--- a/ios/RNGoogleSignin/RNGoogleSignin.m
+++ b/ios/RNGoogleSignin/RNGoogleSignin.m
@@ -22,8 +22,8 @@ static NSString *const ASYNC_OP_IN_PROGRESS = @"ASYNC_OP_IN_PROGRESS";
            @"BUTTON_SIZE_WIDE": @(kGIDSignInButtonStyleWide),
            @"BUTTON_COLOR_LIGHT": @(kGIDSignInButtonColorSchemeLight),
            @"BUTTON_COLOR_DARK": @(kGIDSignInButtonColorSchemeDark),
-           @"SIGNIN_CANCELLED": [@(kGIDSignInErrorCodeCanceled) stringValue],
-           @"ASYNC_OP_IN_PROGRESS": ASYNC_OP_IN_PROGRESS
+           @"CANCEL": [@(kGIDSignInErrorCodeCanceled) stringValue],
+           @"IN_PROGRESS": ASYNC_OP_IN_PROGRESS
            };
 }
 

--- a/ios/RNGoogleSignin/RNGoogleSignin.m
+++ b/ios/RNGoogleSignin/RNGoogleSignin.m
@@ -5,20 +5,25 @@
 
 @property (nonatomic) PromiseWrapper *promiseWrapper;
 
+
 @end
 
 @implementation RNGoogleSignin
 
 RCT_EXPORT_MODULE();
 
+static NSString *const ASYNC_OP_IN_PROGRESS = @"ASYNC_OP_IN_PROGRESS";
+
 - (NSDictionary *)constantsToExport
 {
   return @{
-           @"BUTTON_SIZE_ICON" : @(kGIDSignInButtonStyleIconOnly),
-           @"BUTTON_SIZE_STANDARD" : @(kGIDSignInButtonStyleStandard),
-           @"BUTTON_SIZE_WIDE" : @(kGIDSignInButtonStyleWide),
-           @"BUTTON_COLOR_LIGHT" : @(kGIDSignInButtonColorSchemeLight),
-           @"BUTTON_COLOR_DARK" : @(kGIDSignInButtonColorSchemeDark)
+           @"BUTTON_SIZE_ICON": @(kGIDSignInButtonStyleIconOnly),
+           @"BUTTON_SIZE_STANDARD": @(kGIDSignInButtonStyleStandard),
+           @"BUTTON_SIZE_WIDE": @(kGIDSignInButtonStyleWide),
+           @"BUTTON_COLOR_LIGHT": @(kGIDSignInButtonColorSchemeLight),
+           @"BUTTON_COLOR_DARK": @(kGIDSignInButtonColorSchemeDark),
+           @"SIGNIN_CANCELLED": [@(kGIDSignInErrorCodeCanceled) stringValue],
+           @"ASYNC_OP_IN_PROGRESS": ASYNC_OP_IN_PROGRESS
            };
 }
 
@@ -175,7 +180,7 @@ RCT_REMAP_METHOD(revokeAccess,
 }
 
 - (void)rejectWithAsyncOperationStillInProgress: (RCTPromiseRejectBlock)reject {
-    reject(@"ASYNC_OP_IN_PROGRESS", @"cannot set promise - some async operation is still in progress", nil);
+    reject(ASYNC_OP_IN_PROGRESS, @"cannot set promise - some async operation is still in progress", nil);
 }
 
 + (BOOL)application:(UIApplication *)application openURL:(NSURL *)url

--- a/ios/RNGoogleSignin/RNGoogleSignin.m
+++ b/ios/RNGoogleSignin/RNGoogleSignin.m
@@ -125,11 +125,11 @@ RCT_REMAP_METHOD(revokeAccess,
                                };
     
     NSDictionary *params = @{
+                             @"user": userInfo,
                              @"idToken": user.authentication.idToken,
                              @"serverAuthCode": user.serverAuthCode ? user.serverAuthCode : [NSNull null],
                              @"accessToken": user.authentication.accessToken,
-                             @"accessTokenExpirationDate": [NSNumber numberWithDouble:user.authentication.accessTokenExpirationDate.timeIntervalSinceNow],
-                             @"user": userInfo
+                             @"accessTokenExpirationDate": [NSNumber numberWithDouble:user.authentication.accessTokenExpirationDate.timeIntervalSinceNow]
                              };
     
     [self.promiseWrapper resolve:params];

--- a/src/GoogleSignin.js
+++ b/src/GoogleSignin.js
@@ -60,10 +60,10 @@ class GoogleSignin {
     return RNGoogleSignin.configure(params);
   }
 
-  async getCurrentUser(params) {
+  async signInSilently(params) {
     try {
       await this._configure(params);
-      const user = await RNGoogleSignin.getCurrentUser();
+      const user = await RNGoogleSignin.signInSilently();
       return user;
     } catch (error) {
       return Promise.resolve(null);

--- a/src/GoogleSignin.js
+++ b/src/GoogleSignin.js
@@ -5,18 +5,10 @@ import { NativeModules, Platform } from 'react-native';
 const { RNGoogleSignin } = NativeModules;
 
 const IS_IOS = Platform.OS === 'ios';
-const IS_ANDROID = Platform.OS === 'android';
 
-const isSigninCancellationError = error => {
-  return (IS_IOS && error.code === '-5') || (IS_ANDROID && error.code === '13');
-};
-
-const isSigninInProgressError = error => {
-  return error.code === 'ASYNC_OP_IN_PROGRESS';
-};
-
-export const doesErrorNeedToBeHandled = error => {
-  return !isSigninCancellationError(error) && !isSigninInProgressError(error);
+export const statusCodes = {
+  SIGNIN_CANCELLED: RNGoogleSignin.SIGNIN_CANCELLED,
+  ASYNC_OP_IN_PROGRESS: RNGoogleSignin.ASYNC_OP_IN_PROGRESS,
 };
 
 class GoogleSignin {
@@ -24,14 +16,8 @@ class GoogleSignin {
 
   async signIn() {
     await this.hasPlayServices();
-
-    try {
-      await this.configPromise;
-      const user = await RNGoogleSignin.signIn();
-      return user;
-    } catch (error) {
-      return Promise.reject(error);
-    }
+    await this.configPromise;
+    return await RNGoogleSignin.signIn();
   }
 
   async hasPlayServices(params = { showPlayServicesUpdateDialog: true }) {
@@ -59,8 +45,8 @@ class GoogleSignin {
       await this.hasPlayServices();
 
       await this.configPromise;
-      const user = await RNGoogleSignin.signInSilently();
-      return user;
+      const userInfo = await RNGoogleSignin.signInSilently();
+      return userInfo;
     } catch (error) {
       return Promise.resolve(null);
     }

--- a/src/GoogleSignin.js
+++ b/src/GoogleSignin.js
@@ -6,14 +6,13 @@ const { RNGoogleSignin } = NativeModules;
 
 const IS_IOS = Platform.OS === 'ios';
 const IS_ANDROID = Platform.OS === 'android';
-const PREVIOUS_SIGNIN_IN_PROGRESS = 'RNGoogleSignin: Previous sign in still in progress.';
 
 const isSigninCancellationError = error => {
   return (IS_IOS && error.code === '-5') || (IS_ANDROID && error.code === '13');
 };
 
 const isSigninInProgressError = error => {
-  return error.message === PREVIOUS_SIGNIN_IN_PROGRESS;
+  return error.code === 'ASYNC_OP_IN_PROGRESS';
 };
 
 export const doesErrorNeedToBeHandled = error => {
@@ -21,15 +20,9 @@ export const doesErrorNeedToBeHandled = error => {
 };
 
 class GoogleSignin {
-  isSigninInProgress = false;
   configPromise;
 
   async signIn() {
-    if (this.isSigninInProgress) {
-      return Promise.reject(new Error(PREVIOUS_SIGNIN_IN_PROGRESS));
-    }
-    this.isSigninInProgress = true;
-
     await this.hasPlayServices();
 
     try {
@@ -38,8 +31,6 @@ class GoogleSignin {
       return user;
     } catch (error) {
       return Promise.reject(error);
-    } finally {
-      this.isSigninInProgress = false;
     }
   }
 
@@ -64,10 +55,6 @@ class GoogleSignin {
   }
 
   async signInSilently() {
-    if (this.isSigninInProgress) {
-      return Promise.reject(new Error(PREVIOUS_SIGNIN_IN_PROGRESS));
-    }
-    this.isSigninInProgress = true;
     try {
       await this.hasPlayServices();
 
@@ -76,8 +63,6 @@ class GoogleSignin {
       return user;
     } catch (error) {
       return Promise.resolve(null);
-    } finally {
-      this.isSigninInProgress = false;
     }
   }
 

--- a/src/GoogleSignin.js
+++ b/src/GoogleSignin.js
@@ -7,8 +7,8 @@ const { RNGoogleSignin } = NativeModules;
 const IS_IOS = Platform.OS === 'ios';
 
 export const statusCodes = {
-  SIGNIN_CANCELLED: RNGoogleSignin.SIGNIN_CANCELLED,
-  ASYNC_OP_IN_PROGRESS: RNGoogleSignin.ASYNC_OP_IN_PROGRESS,
+  CANCEL: RNGoogleSignin.CANCEL,
+  IN_PROGRESS: RNGoogleSignin.IN_PROGRESS,
 };
 
 class GoogleSignin {

--- a/src/GoogleSignin.js
+++ b/src/GoogleSignin.js
@@ -7,7 +7,7 @@ const { RNGoogleSignin } = NativeModules;
 const IS_IOS = Platform.OS === 'ios';
 
 export const statusCodes = {
-  CANCEL: RNGoogleSignin.CANCEL,
+  SIGN_IN_CANCELLED: RNGoogleSignin.SIGN_IN_CANCELLED,
   IN_PROGRESS: RNGoogleSignin.IN_PROGRESS,
 };
 

--- a/src/GoogleSignin.js
+++ b/src/GoogleSignin.js
@@ -60,9 +60,10 @@ class GoogleSignin {
     return RNGoogleSignin.configure(params);
   }
 
-  async getCurrentUser() {
+  async getCurrentUser(params) {
     try {
-      const user = await RNGoogleSignin.currentUserAsync();
+      await this._configure(params);
+      const user = await RNGoogleSignin.getCurrentUser();
       return user;
     } catch (error) {
       return Promise.resolve(null);

--- a/src/GoogleSignin.js
+++ b/src/GoogleSignin.js
@@ -14,6 +14,10 @@ const { RNGoogleSignin } = NativeModules;
 const IS_IOS = Platform.OS === 'ios';
 const IS_ANDROID = Platform.OS === 'android';
 
+export const isSigninCancellation = error => {
+  return (IS_IOS && error.code === '-5') || (IS_ANDROID && error.code === '12501');
+};
+
 class GoogleSignin {
   signinIsInProcess = false;
 
@@ -30,9 +34,6 @@ class GoogleSignin {
       const user = await RNGoogleSignin.signIn();
       return user;
     } catch (error) {
-      if ((IS_IOS && error.code === '-5') || (IS_ANDROID && error.code === '12501')) {
-        return Promise.resolve({ type: 'cancel' });
-      }
       return Promise.reject(error);
     } finally {
       this.signinIsInProcess = false;

--- a/src/GoogleSignin.js
+++ b/src/GoogleSignin.js
@@ -8,7 +8,7 @@ const IS_IOS = Platform.OS === 'ios';
 const IS_ANDROID = Platform.OS === 'android';
 const PREVIOUS_SIGNIN_IN_PROGRESS = 'RNGoogleSignin: Previous sign in still in progress.';
 
-const isSigninCancellation = error => {
+const isSigninCancellationError = error => {
   return (IS_IOS && error.code === '-5') || (IS_ANDROID && error.code === '13');
 };
 
@@ -17,7 +17,7 @@ const isSigninInProgressError = error => {
 };
 
 export const doesErrorNeedToBeHandled = error => {
-  return !isSigninCancellation(error) && !isSigninInProgressError(error);
+  return !isSigninCancellationError(error) && !isSigninInProgressError(error);
 };
 
 class GoogleSignin {

--- a/src/GoogleSignin.js
+++ b/src/GoogleSignin.js
@@ -29,7 +29,6 @@ export const doesErrorNeedToBeHandled = error => {
 
 class GoogleSignin {
   isSigninInProgress = false;
-  isSilentSigninInProgress = false;
   configPromise;
 
   async signIn() {
@@ -72,10 +71,10 @@ class GoogleSignin {
   }
 
   async signInSilently() {
-    if (this.isSilentSigninInProgress) {
+    if (this.isSigninInProgress) {
       return Promise.reject(new Error(PREVIOUS_SIGNIN_IN_PROGRESS));
     }
-    this.isSilentSigninInProgress = true;
+    this.isSigninInProgress = true;
     try {
       await this.hasPlayServices();
 
@@ -85,7 +84,7 @@ class GoogleSignin {
     } catch (error) {
       return Promise.resolve(null);
     } finally {
-      this.isSilentSigninInProgress = false;
+      this.isSigninInProgress = false;
     }
   }
 

--- a/src/GoogleSignin.js
+++ b/src/GoogleSignin.js
@@ -1,13 +1,6 @@
 import React, { Component } from 'react';
 
-import {
-  View,
-  NativeAppEventEmitter,
-  NativeModules,
-  requireNativeComponent,
-  ViewPropTypes,
-  Platform,
-} from 'react-native';
+import { NativeModules, Platform } from 'react-native';
 
 const { RNGoogleSignin } = NativeModules;
 

--- a/src/GoogleSignin.js
+++ b/src/GoogleSignin.js
@@ -13,69 +13,88 @@ const { RNGoogleSignin } = NativeModules;
 
 const IS_IOS = Platform.OS === 'ios';
 const IS_ANDROID = Platform.OS === 'android';
+const PREVIOUS_SIGNIN_IN_PROGRESS = 'RNGoogleSignin: Previous sign in still in progress.';
 
-export const isSigninCancellation = error => {
-  return (IS_IOS && error.code === '-5') || (IS_ANDROID && error.code === '12501');
+const isSigninCancellation = error => {
+  return (IS_IOS && error.code === '-5') || (IS_ANDROID && error.code === '13');
+};
+
+const isSigninInProgressError = error => {
+  return error.message === PREVIOUS_SIGNIN_IN_PROGRESS;
+};
+
+export const doesErrorNeedToBeHandled = error => {
+  return !isSigninCancellation(error) && !isSigninInProgressError(error);
 };
 
 class GoogleSignin {
-  signinIsInProcess = false;
+  isSigninInProgress = false;
+  isSilentSigninInProgress = false;
+  configPromise;
 
-  async signIn(params) {
-    if (this.signinIsInProcess) {
-      return Promise.reject(new Error('RNGoogleSignin: Previous sign in still in progress.'));
+  async signIn() {
+    if (this.isSigninInProgress) {
+      return Promise.reject(new Error(PREVIOUS_SIGNIN_IN_PROGRESS));
     }
-    this.signinIsInProcess = true;
+    this.isSigninInProgress = true;
 
-    await this.hasPlayServices(params);
-    await this._configure(params);
+    await this.hasPlayServices();
 
     try {
+      await this.configPromise;
       const user = await RNGoogleSignin.signIn();
       return user;
     } catch (error) {
       return Promise.reject(error);
     } finally {
-      this.signinIsInProcess = false;
+      this.isSigninInProgress = false;
     }
   }
 
-  async hasPlayServices({ autoResolveGooglePlayError = true }) {
+  async hasPlayServices(params = { showPlayServicesUpdateDialog: true }) {
     if (IS_IOS) {
       return true;
     } else {
-      return RNGoogleSignin.playServicesAvailable(autoResolveGooglePlayError);
+      return RNGoogleSignin.playServicesAvailable(params.showPlayServicesUpdateDialog);
     }
   }
 
-  async _configure(params = {}) {
+  configure(params = {}) {
     if (IS_IOS && !params.iosClientId) {
-      return Promise.reject(new Error('RNGoogleSignin: Missing iOS app ClientID'));
+      return new Error('RNGoogleSignin: Missing iOS app ClientID');
     }
 
     if (params.offlineAccess && !params.webClientId) {
-      return Promise.reject(new Error('RNGoogleSignin: offline use requires server web ClientID'));
+      return new Error('RNGoogleSignin: offline use requires server web ClientID');
     }
 
-    return RNGoogleSignin.configure(params);
+    this.configPromise = RNGoogleSignin.configure(params);
   }
 
-  async signInSilently(params) {
+  async signInSilently() {
+    if (this.isSilentSigninInProgress) {
+      return Promise.reject(new Error(PREVIOUS_SIGNIN_IN_PROGRESS));
+    }
+    this.isSilentSigninInProgress = true;
     try {
-      await this._configure(params);
+      await this.hasPlayServices();
+
+      await this.configPromise;
       const user = await RNGoogleSignin.signInSilently();
       return user;
     } catch (error) {
       return Promise.resolve(null);
+    } finally {
+      this.isSilentSigninInProgress = false;
     }
   }
 
   async signOut() {
-    return await RNGoogleSignin.signOut();
+    return RNGoogleSignin.signOut();
   }
 
   async revokeAccess() {
-    return await RNGoogleSignin.revokeAccess();
+    return RNGoogleSignin.revokeAccess();
   }
 }
 

--- a/src/GoogleSignin.js
+++ b/src/GoogleSignin.js
@@ -15,19 +15,39 @@ const IS_IOS = Platform.OS === 'ios';
 const IS_ANDROID = Platform.OS === 'android';
 
 class GoogleSignin {
-  // TODO vonovak kill state in this module
-  _user = null;
   signinIsInProcess = false;
 
-  hasPlayServices(params = { autoResolve: true }) {
-    if (IS_IOS) {
-      return Promise.resolve(true);
-    } else {
-      return RNGoogleSignin.playServicesAvailable(params.autoResolve);
+  async signIn(params) {
+    if (this.signinIsInProcess) {
+      return Promise.reject(new Error('RNGoogleSignin: Previous sign in still in progress.'));
+    }
+    this.signinIsInProcess = true;
+
+    await this.hasPlayServices(params);
+    await this._configure(params);
+
+    try {
+      const user = await RNGoogleSignin.signIn();
+      return user;
+    } catch (error) {
+      if ((IS_IOS && error.code === '-5') || (IS_ANDROID && error.code === '12501')) {
+        return Promise.resolve({ type: 'cancel' });
+      }
+      return Promise.reject(error);
+    } finally {
+      this.signinIsInProcess = false;
     }
   }
 
-  async configure(params = {}) {
+  async hasPlayServices({ autoResolveGooglePlayError = true }) {
+    if (IS_IOS) {
+      return true;
+    } else {
+      return RNGoogleSignin.playServicesAvailable(autoResolveGooglePlayError);
+    }
+  }
+
+  async _configure(params = {}) {
     if (IS_IOS && !params.iosClientId) {
       return Promise.reject(new Error('RNGoogleSignin: Missing iOS app ClientID'));
     }
@@ -39,57 +59,21 @@ class GoogleSignin {
     return RNGoogleSignin.configure(params);
   }
 
-  async currentUserAsync() {
+  async getCurrentUser() {
     try {
       const user = await RNGoogleSignin.currentUserAsync();
-      this._user = { ...user };
       return user;
     } catch (error) {
-      this.signinIsInProcess = false;
-
       return Promise.resolve(null);
     }
   }
 
-  currentUser() {
-    if (this._user) {
-      return { ...this._user };
-    }
-    return null;
-  }
-
-  async signIn() {
-    if (this.signinIsInProcess) {
-      return Promise.reject(new Error('RNGoogleSignin: Previous sign in still in progress.'));
-    }
-
-    this.signinIsInProcess = true;
-    try {
-      const user = await RNGoogleSignin.signIn();
-      this._user = { ...user };
-      return user;
-    } catch (error) {
-      // TODO figure out a nice api that communicates this to the user
-      // I'd go for expo's way: https://docs.expo.io/versions/latest/sdk/google
-      if ((IS_IOS && error.code === '-5') || (IS_ANDROID && error.code === '12501')) {
-        error.code = 'CANCELED';
-      }
-      return Promise.reject(error);
-    } finally {
-      this.signinIsInProcess = false;
-    }
-  }
-
   async signOut() {
-    const result = await RNGoogleSignin.signOut();
-    this._user = null;
-    return result;
+    return await RNGoogleSignin.signOut();
   }
 
   async revokeAccess() {
-    const result = await RNGoogleSignin.revokeAccess();
-    this._user = null;
-    return result;
+    return await RNGoogleSignin.revokeAccess();
   }
 }
 


### PR DESCRIPTION
closes #450 

sorry for huge diff

Some background is given there, although I did not follow the suggestions entirely: the `type: 'success'/'cancel'` field is not included.

breaking:

- `configure` is sync, does not return a promise. It *does* need to be called before any other exposed methods are called, typically only **once**. I took approach nr 4 from https://github.com/react-native-community/react-native-google-signin/issues/450#issuecomment-406899092 since it just seemed best to me, but am open to discussing the best one.
- `currentUser` function is removed

- renamed `autoResolve` => `showPlayServicesUpdateDialog`
- renamed `currentUserAsync` => `signInSilently` (the new name is much closer to the name of the underlying native methods)

- changed shape of data returned from `signIn` and `signInSilently`:

```js
{
 idToken,
 serverAuthCode,
 user: {
   name,
   email,
   ...
 }
}
```

We export a `statusCodes` object: 

```js
export const statusCodes = {
  SIGN_IN_CANCELLED: RNGoogleSignin.SIGN_IN_CANCELLED,
  IN_PROGRESS: RNGoogleSignin.IN_PROGRESS,
};
```

the constants can be used in the catch block to find out if the error was a canceled sign in

the `hasPlayServices` is still exposed and people can use it to check, well, if google play is available (this will always be true on ios, but may not be true on android). The call will by default show an alert that offers user to update the google play services. However, calling it is not obligatory - `hasPlayServices` is called by `signIn` and `signInSilently` automatically, every time they are called (up for discussion).
