### PR TITLE
Add support to assembleRelease verifyReleaseResources RN 0.56

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,12 +23,12 @@ allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
         ndk {


### PR DESCRIPTION
Fixed it => Execution failed for task ':react-native-google-singin:verifyReleaseResources'.