### PR TITLE
Deprecate accessTokenExpirationDate

### DIFF
--- a/android/src/main/java/co/apptailor/googlesignin/Utils.java
+++ b/android/src/main/java/co/apptailor/googlesignin/Utils.java
@@ -42,7 +42,7 @@ public class Utils {
         params.putString("idToken", acct.getIdToken());
         params.putString("serverAuthCode", acct.getServerAuthCode());
         params.putString("accessToken", null);
-        params.putString("accessTokenExpirationDate", null);
+        params.putString("accessTokenExpirationDate", null); // Deprecated as of 2018-08-06
 
         WritableArray scopes = Arguments.createArray();
         for(Scope scope : acct.getGrantedScopes()) {

--- a/ios/RNGoogleSignin/RNGoogleSignin.m
+++ b/ios/RNGoogleSignin/RNGoogleSignin.m
@@ -128,14 +128,14 @@ RCT_REMAP_METHOD(revokeAccess,
                                @"photo": imageURL ? imageURL.absoluteString : [NSNull null],
                                @"email": user.profile.email
                                };
-    
+
     NSDictionary *params = @{
                              @"user": userInfo,
                              @"idToken": user.authentication.idToken,
                              @"serverAuthCode": user.serverAuthCode ? user.serverAuthCode : [NSNull null],
                              @"accessToken": user.authentication.accessToken,
                              @"scopes": user.accessibleScopes,
-                             @"accessTokenExpirationDate": [NSNumber numberWithDouble:user.authentication.accessTokenExpirationDate.timeIntervalSinceNow]
+                             @"accessTokenExpirationDate": [NSNumber numberWithDouble:user.authentication.accessTokenExpirationDate.timeIntervalSinceNow] // Deprecated as of 2018-08-06
                              };
     
     [self.promiseWrapper resolve:params];
@@ -185,7 +185,7 @@ RCT_REMAP_METHOD(revokeAccess,
 }
 
 + (BOOL)application:(UIApplication *)application openURL:(NSURL *)url
-  sourceApplication:(NSString *)sourceApplication annotation:(id)annotation {
+  sourceApplication:(NSString *)sourceApplication annotation: (id)annotation {
 
     return [[GIDSignIn sharedInstance] handleURL:url
                                sourceApplication:sourceApplication


### PR DESCRIPTION
It's not recommended to build your app around expiration date of very short lived token. Also this is not available on Android.