### PR TITLE
add `disabled` prop to GoogleSigninButton

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ render() {
     style={{ width: 48, height: 48 }}
     size={GoogleSigninButton.Size.Icon}
     color={GoogleSigninButton.Color.Dark}
-    onPress={this._signIn}/>
+    onPress={this._signIn}
+    disabled={this.state.isSigninInProgress} />
 }
 ```
 

--- a/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninButtonViewManager.java
+++ b/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninButtonViewManager.java
@@ -38,4 +38,9 @@ public class RNGoogleSigninButtonViewManager extends SimpleViewManager<SignInBut
     public void setColor(SignInButton button, int color) {
         button.setColorScheme(color);
     }
+
+    @ReactProp(name = "disabled")
+    public void setDisabled(SignInButton button, boolean disabled) {
+        button.setEnabled(!disabled);
+    }
 }

--- a/ios/RNGoogleSignin/RNGoogleSigninButtonManager.m
+++ b/ios/RNGoogleSignin/RNGoogleSigninButtonManager.m
@@ -32,6 +32,11 @@ RCT_CUSTOM_VIEW_PROPERTY(size, NSString, RNGoogleSignInButton)
   view.style = json ? [RCTConvert GIDSignInButtonStyle:json] : kGIDSignInButtonStyleStandard;
 }
 
+RCT_CUSTOM_VIEW_PROPERTY(disabled, BOOL, RNGoogleSignInButton)
+{
+  view.enabled = ![RCTConvert BOOL:json];
+}
+
 RCT_EXPORT_VIEW_PROPERTY(onPress, RCTBubblingEventBlock)
 
 -(void)onPress:(RNGoogleSignInButton *)sender

--- a/src/GoogleSigninButton.android.js
+++ b/src/GoogleSigninButton.android.js
@@ -18,6 +18,7 @@ export class GoogleSigninButton extends Component {
     ...ViewPropTypes,
     size: PropTypes.number,
     color: PropTypes.number,
+    disabled: PropTypes.bool,
   };
 
   componentDidMount() {

--- a/src/GoogleSigninButton.ios.js
+++ b/src/GoogleSigninButton.ios.js
@@ -17,6 +17,7 @@ export class GoogleSigninButton extends Component {
     ...ViewPropTypes,
     size: PropTypes.number,
     color: PropTypes.number,
+    disabled: PropTypes.bool,
     onPress: PropTypes.func.isRequired,
   };
 


### PR DESCRIPTION
Add a `disabled` prop to `GoogleSigninButton` to make it more consistent with RN's `Button` and `Touchable*`.