### PR TITLE
change signInSilently(), reformat and rename PromiseWrapper on ios

### DIFF
--- a/.github/ISSUE_TEMPLATE/Custom.md
+++ b/.github/ISSUE_TEMPLATE/Custom.md
@@ -2,7 +2,6 @@
 name: New issue template
 about: Template for new issues, any issues not following these templates will be automatically
   closed
-
 ---
 
 <!--
@@ -13,7 +12,7 @@ Please make sure you have searched previous issues before opening a new issue.
 
 ## Steps to Reproduce
 
-- You must provide a **minimal** reproduction of your issue - [how to create a minimal reproduction?](https://stackoverflow.com/help/mcve). We're a small team of maintainers and do not have time to try reproduce bugs ourselves.
+- You must provide a **minimal** reproduction of your issue - [how to create a minimal reproduction?](https://stackoverflow.com/help/mcve). We're a small team of maintainers and do not have time to try reproduce bugs ourselves. Please try to reproduce the bugs on the provided example app.
 
 - Link to a with code that reproduces the bug.
 

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ render() {
 
 Possible values for `size` are:
 
-- Size.Icon: display only Google icon. recommended size of 48 x 48
-- Size.Standard: icon with 'Sign in'. recommended size of 230 x 48
-- Size.Wide: icon with 'Sign in with Google'. recommended size of 312 x 48
+- Size.Icon: display only Google icon. Recommended size of 48 x 48.
+- Size.Standard: icon with 'Sign in'. Recommended size of 230 x 48.
+- Size.Wide: icon with 'Sign in with Google'. Recommended size of 312 x 48.
 
 Possible values for `color` are:
 

--- a/README.md
+++ b/README.md
@@ -17,13 +17,6 @@
 - Consistent API between Android and iOS
 - Promise-based JS API
 
-## Installation
-
-```bash
-npm install react-native-google-signin --save
-react-native link react-native-google-signin
-```
-
 ### Note
 
 If you use React Native < `v0.40` stick with `v0.8.1` (`npm install react-native-google-signin@0.8 --save`).
@@ -130,7 +123,7 @@ signIn = async () => {
 
 #### `signInSilently()`
 
-May be called eg. in the `componentDidMount` of your main component. This method returns the [current user](#3-userinfo) if they already signed in and `null` otherwise.
+May be called eg. in the `componentDidMount` of your main component. This method returns the [current user](#3-userinfo) and rejects with an error otherwise.
 
 To see how to handle errors read [`signIn()` method](#signin)
 
@@ -230,6 +223,10 @@ Example `userInfo` which is returned after successful sign in.
   }
 }
 ```
+
+## Notes
+
+Calling the methods exposed by this package may involve remote network calls and you should thus take into account that such calls may take a long time to complete (eg. in case of poor network connection).
 
 **idToken Note**: idToken is not null only if you specify a valid `webClientId`. `webClientId` corresponds to your server clientID on the developers console. It **HAS TO BE** of type **WEB**
 

--- a/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninPackage.java
+++ b/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninPackage.java
@@ -1,16 +1,12 @@
 package co.apptailor.googlesignin;
 
-import android.app.Activity;
-
 import com.facebook.react.ReactPackage;
-import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 public class RNGoogleSigninPackage implements ReactPackage {

--- a/android/src/main/java/co/apptailor/googlesignin/Utils.java
+++ b/android/src/main/java/co/apptailor/googlesignin/Utils.java
@@ -45,7 +45,7 @@ public class Utils {
         params.putString("accessTokenExpirationDate", null); // Deprecated as of 2018-08-06
 
         WritableArray scopes = Arguments.createArray();
-        for(Scope scope : acct.getGrantedScopes()) {
+        for (Scope scope : acct.getGrantedScopes()) {
             String scopeString = scope.toString();
             if (scopeString.startsWith("http")) {
                 scopes.pushString(scopeString);

--- a/get-config-file.md
+++ b/get-config-file.md
@@ -2,18 +2,17 @@
 
 If you don't already have a project in Firebase you need to create one in order to generate credentials for an IOS and Android application
 
-
 [Firebase console](https://console.firebase.google.com/u/0/)
 
-1) Add your IOS and Android App inside Project settings.
+1. Add your IOS and Android App inside Project settings.
 
 ![Project settings](img/project-settings.png)
 
-*Access project settings on top left pane next to Project Overview*
+_Access project settings on top left pane next to Project Overview_
 
-2) During the Add App process download the config file.
+2. During the Add App process download the config file.
 
-*Note: For android SHA1 key is obligation*
+_Note: For Android, having the SHA1 key is an obligation_
 
 To get the SHA1 key you need to generate your keystore, to generate your keystore follow [this guide](https://facebook.github.io/react-native/docs/signed-apk-android.html)
 
@@ -23,11 +22,7 @@ You can use your debug keystore's SHA1 value, get it by running this command ins
 
 This should print out a SHA1 key.
 
-
 ## WebClientId
 
-webClientId will be automatically generated once you create the app in the firebase console.
+`webClientId` will be automatically generated once you create the app in the firebase console.
 You can access the `webClientId` [here](https://console.developers.google.com/apis/credentials). Make sure you select the correct project. `webClientId` should be under OAuth section.
-
-
-

--- a/ios/RNGoogleSignin.xcodeproj/project.pbxproj
+++ b/ios/RNGoogleSignin.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		04A616CC20B85BA800B435C6 /* RNGoogleSignInButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 04A616CB20B85BA800B435C6 /* RNGoogleSignInButton.m */; };
-		79384FBB2114DF7400F3D9BD /* PromiseWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 79384FBA2114DF7400F3D9BD /* PromiseWrapper.m */; };
+		79384FBB2114DF7400F3D9BD /* RNGSPromiseWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 79384FBA2114DF7400F3D9BD /* RNGSPromiseWrapper.m */; };
 		9FD355211D3E4ACC00D06170 /* RNGoogleSignin.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FD3551F1D3E4ACC00D06170 /* RNGoogleSignin.m */; };
 		9FD355221D3E4ACC00D06170 /* RNGoogleSigninButtonManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FD355201D3E4ACC00D06170 /* RNGoogleSigninButtonManager.m */; };
 		9FD355331D3E4D3600D06170 /* RNGoogleSignin.h in Copy Header */ = {isa = PBXBuildFile; fileRef = 9FD3551E1D3E4ACC00D06170 /* RNGoogleSignin.h */; };
@@ -31,8 +31,8 @@
 /* Begin PBXFileReference section */
 		04A616CA20B85BA800B435C6 /* RNGoogleSignInButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNGoogleSignInButton.h; sourceTree = "<group>"; };
 		04A616CB20B85BA800B435C6 /* RNGoogleSignInButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNGoogleSignInButton.m; sourceTree = "<group>"; };
-		79384FB92114DF7400F3D9BD /* PromiseWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PromiseWrapper.h; sourceTree = "<group>"; };
-		79384FBA2114DF7400F3D9BD /* PromiseWrapper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PromiseWrapper.m; sourceTree = "<group>"; };
+		79384FB92114DF7400F3D9BD /* RNGSPromiseWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNGSPromiseWrapper.h; sourceTree = "<group>"; };
+		79384FBA2114DF7400F3D9BD /* RNGSPromiseWrapper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNGSPromiseWrapper.m; sourceTree = "<group>"; };
 		9FD355121D3E4A2900D06170 /* libRNGoogleSignin.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNGoogleSignin.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		9FD3551E1D3E4ACC00D06170 /* RNGoogleSignin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNGoogleSignin.h; sourceTree = "<group>"; };
 		9FD3551F1D3E4ACC00D06170 /* RNGoogleSignin.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNGoogleSignin.m; sourceTree = "<group>"; };
@@ -69,8 +69,8 @@
 		9FD355141D3E4A2900D06170 /* RNGoogleSignin */ = {
 			isa = PBXGroup;
 			children = (
-				79384FB92114DF7400F3D9BD /* PromiseWrapper.h */,
-				79384FBA2114DF7400F3D9BD /* PromiseWrapper.m */,
+				79384FB92114DF7400F3D9BD /* RNGSPromiseWrapper.h */,
+				79384FBA2114DF7400F3D9BD /* RNGSPromiseWrapper.m */,
 				04A616CA20B85BA800B435C6 /* RNGoogleSignInButton.h */,
 				04A616CB20B85BA800B435C6 /* RNGoogleSignInButton.m */,
 				9FD3551E1D3E4ACC00D06170 /* RNGoogleSignin.h */,
@@ -139,7 +139,7 @@
 				04A616CC20B85BA800B435C6 /* RNGoogleSignInButton.m in Sources */,
 				9FD355221D3E4ACC00D06170 /* RNGoogleSigninButtonManager.m in Sources */,
 				9FD355211D3E4ACC00D06170 /* RNGoogleSignin.m in Sources */,
-				79384FBB2114DF7400F3D9BD /* PromiseWrapper.m in Sources */,
+				79384FBB2114DF7400F3D9BD /* RNGSPromiseWrapper.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/RNGoogleSignin/RNGSPromiseWrapper.h
+++ b/ios/RNGoogleSignin/RNGSPromiseWrapper.h
@@ -10,7 +10,7 @@
 #define PromiseWrapper_h
 #import <React/RCTBridgeModule.h>
 
-@interface PromiseWrapper : NSObject
+@interface RNGSPromiseWrapper : NSObject
 
 -(BOOL) setPromiseWithInProgressCheck:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject;
 -(void) resolve: (id) result;

--- a/ios/RNGoogleSignin/RNGSPromiseWrapper.m
+++ b/ios/RNGoogleSignin/RNGSPromiseWrapper.m
@@ -7,17 +7,17 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "PromiseWrapper.h"
+#import "RNGSPromiseWrapper.h"
 
 
-@interface PromiseWrapper ()
+@interface RNGSPromiseWrapper ()
 
 @property (nonatomic, strong) RCTPromiseResolveBlock promiseResolve;
 @property (nonatomic, strong) RCTPromiseRejectBlock promiseReject;
 
 @end
 
-@implementation PromiseWrapper
+@implementation RNGSPromiseWrapper
 
 -(BOOL) setPromiseWithInProgressCheck: (RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject {
   BOOL success = NO;

--- a/ios/RNGoogleSignin/RNGoogleSigninButtonManager.m
+++ b/ios/RNGoogleSignin/RNGoogleSigninButtonManager.m
@@ -15,10 +15,10 @@ RCT_EXPORT_MODULE()
   RNGoogleSignInButton *button = [[RNGoogleSignInButton alloc] init];
   button.colorScheme = kGIDSignInButtonColorSchemeLight;
   button.style = kGIDSignInButtonStyleStandard;
-
+  
   [button removeTarget:nil action:NULL forControlEvents:UIControlEventTouchUpInside];
   [button addTarget:self action:@selector(onPress:) forControlEvents:UIControlEventTouchUpInside];
-
+  
   return button;
 }
 
@@ -44,7 +44,7 @@ RCT_EXPORT_VIEW_PROPERTY(onPress, RCTBubblingEventBlock)
   if (!sender.onPress) {
     return;
   }
-
+  
   sender.onPress(nil);
 }
 

--- a/src/GoogleSignin.js
+++ b/src/GoogleSignin.js
@@ -41,13 +41,8 @@ class GoogleSignin {
   }
 
   async signInSilently() {
-    try {
-      await this.configPromise;
-      const userInfo = await RNGoogleSignin.signInSilently();
-      return userInfo;
-    } catch (error) {
-      return Promise.resolve(null);
-    }
+    await this.configPromise;
+    return RNGoogleSignin.signInSilently();
   }
 
   async signOut() {


### PR DESCRIPTION
partially addresses #480

on ios, I reformatted the code to use 2-sapce indent since the majority of the code is written that way - the diff is still large but there are *no changes* done to the code other than indetation. On android, everything has 4-space indents, so I kept that.

I renamed `PromiseWrapper` to `RNGSPromiseWrapper`, but am open to another name


`signInSilently` rejects if it does not obtain user info. This is breaking, but it is in line with how `signIn` works and also allows users to find out what kind of error happened if the call rejects.