### PR TITLE
Unsafe passing nullable parameter

### DIFF
--- a/src/GoogleSignin.js
+++ b/src/GoogleSignin.js
@@ -24,6 +24,9 @@ class GoogleSignin {
     if (IS_IOS) {
       return true;
     } else {
+      if (params && params.showPlayServicesUpdateDialog === undefined) {
+        throw new Error('RNGoogleSignin: Missing property `showPlayServicesUpdateDialog` in params object for `hasPlayServices`');
+      }
       return RNGoogleSignin.playServicesAvailable(params.showPlayServicesUpdateDialog);
     }
   }


### PR DESCRIPTION
Passing an empty object or an object without property **showPlayServicesUpdateDialog** to **hasPlayServices** caused app crash on Android.

<img width="448" alt="screen shot 2018-08-24 at 2 08 02 pm" src="https://user-images.githubusercontent.com/6320796/44570185-219b4100-a7a7-11e8-8bb6-9079b0268c57.png">
