### PR TITLE
[iOS] Remove `iosClientId` requirement from JS side

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,21 +76,19 @@ Handler to be called when the user taps the button
 ### 2. GoogleSignin
 
 ```js
-import { GoogleSignin, GoogleSigninButton } from 'react-native-google-signin';
+import { GoogleSignin, GoogleSigninButton, statusCodes } from 'react-native-google-signin';
 ```
 
-#### `configure(configuration)`
+#### `configure(options)`
 
 It is mandatory to call this method before attempting to call `signIn()` and `signInSilently()`. This method is sync meaning you can call `signIn` / `signInSilently` right after it. In typical scenarios, `configure` needs to be called only once, after your app starts.
 
-Example for default configuration: you get user email and basic profile info.
+Example usage with for default options: you get user email and basic profile info.
 
 ```js
-import { GoogleSignin, GoogleSigninButton } from 'react-native-google-signin';
+import { GoogleSignin } from 'react-native-google-signin';
 
-GoogleSignin.configure({
-  iosClientId: '<FROM DEVELOPER CONSOLE>', // only for iOS
-});
+GoogleSignin.configure();
 ```
 
 Example to access Google Drive both from the mobile application and from the backend server
@@ -98,7 +96,6 @@ Example to access Google Drive both from the mobile application and from the bac
 ```js
 GoogleSignin.configure({
   scopes: ['https://www.googleapis.com/auth/drive.readonly'], // what API you want to access on behalf of the user, default is email and profile
-  iosClientId: '<FROM DEVELOPER CONSOLE>', // only for iOS
   webClientId: '<FROM DEVELOPER CONSOLE>', // client ID of type WEB for your server (needed to verify user ID and offline access)
   offlineAccess: true, // if you want to access Google API on behalf of the user FROM YOUR SERVER
   hostedDomain: '', // specifies a hosted domain restriction
@@ -106,8 +103,6 @@ GoogleSignin.configure({
   accountName: '', // [Android] specifies an account name on the device that should be used
 });
 ```
-
-**iOS Note**: your app ClientID (`iosClientId`) is always required
 
 #### `signIn()`
 
@@ -185,7 +180,7 @@ revokeAccess = async () => {
 };
 ```
 
-#### hasPlayServices(paramObject)
+#### hasPlayServices(options)
 
 Check if device has Google Play Services installed. Always resolves to true on iOS.
 

--- a/example/index.js
+++ b/example/index.js
@@ -5,7 +5,6 @@ import {
   Text,
   View,
   TouchableOpacity,
-  Platform,
   Alert,
 } from 'react-native';
 
@@ -27,17 +26,7 @@ class GoogleSigninSampleApp extends Component {
   }
 
   _configureGoogleSignIn() {
-    const configPlatform = {
-      ...Platform.select({
-        ios: {
-          iosClientId: config.iosClientId,
-        },
-        android: {},
-      }),
-    };
-
     GoogleSignin.configure({
-      ...configPlatform,
       webClientId: config.webClientId,
       offlineAccess: false,
     });

--- a/ios/RNGoogleSignin/RNGoogleSignin.m
+++ b/ios/RNGoogleSignin/RNGoogleSignin.m
@@ -1,3 +1,4 @@
+#import <React/RCTLog.h>
 #import "RNGoogleSignin.h"
 #import "RNGSPromiseWrapper.h"
 
@@ -14,6 +15,10 @@ RCT_EXPORT_MODULE();
 
 static NSString *const ASYNC_OP_IN_PROGRESS = @"ASYNC_OP_IN_PROGRESS";
 static NSString *const PLAY_SERVICES_NOT_AVAILABLE = @"PLAY_SERVICES_NOT_AVAILABLE";
+
+// The key in `GoogleService-Info.plist` client id.
+// For more see https://developers.google.com/identity/sign-in/ios/start
+static NSString *const kClientIdKey = @"CLIENT_ID";
 
 - (NSDictionary *)constantsToExport
 {
@@ -51,11 +56,21 @@ RCT_EXPORT_METHOD(configure:(NSDictionary *)options
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
+  NSString *path = [[NSBundle mainBundle] pathForResource:@"GoogleService-Info" ofType:@"plist"];
+
+  if (!path) {
+    RCTLogError(@"RNGoogleSignin: Missing GoogleService-Info.plist");
+    reject(@"INTERNAL_MISSING_CONFIG", @"Missing GoogleService-Info.plist", nil);
+    return;
+  }
+
+  NSMutableDictionary *plist = [[NSMutableDictionary alloc] initWithContentsOfFile:path];
+
   [GIDSignIn sharedInstance].delegate = self;
   [GIDSignIn sharedInstance].uiDelegate = self;
   [GIDSignIn sharedInstance].scopes = options[@"scopes"];
   [GIDSignIn sharedInstance].shouldFetchBasicProfile = YES; // email, profile
-  [GIDSignIn sharedInstance].clientID = options[@"iosClientId"];
+  [GIDSignIn sharedInstance].clientID = plist[kClientIdKey];
   
   if (options[@"hostedDomain"]) {
     [GIDSignIn sharedInstance].hostedDomain = options[@"hostedDomain"];

--- a/ios/RNGoogleSignin/RNGoogleSignin.m
+++ b/ios/RNGoogleSignin/RNGoogleSignin.m
@@ -64,7 +64,7 @@ RCT_EXPORT_METHOD(configure:(NSDictionary *)options
     return;
   }
 
-  NSMutableDictionary *plist = [[NSMutableDictionary alloc] initWithContentsOfFile:path];
+  NSDictionary *plist = [[NSDictionary alloc] initWithContentsOfFile:path];
 
   [GIDSignIn sharedInstance].delegate = self;
   [GIDSignIn sharedInstance].uiDelegate = self;

--- a/src/GoogleSignin.js
+++ b/src/GoogleSignin.js
@@ -20,27 +20,23 @@ class GoogleSignin {
     return await RNGoogleSignin.signIn();
   }
 
-  async hasPlayServices(params = { showPlayServicesUpdateDialog: true }) {
+  async hasPlayServices(options = { showPlayServicesUpdateDialog: true }) {
     if (IS_IOS) {
       return true;
     } else {
-      if (params && params.showPlayServicesUpdateDialog === undefined) {
-        throw new Error('RNGoogleSignin: Missing property `showPlayServicesUpdateDialog` in params object for `hasPlayServices`');
+      if (options && options.showPlayServicesUpdateDialog === undefined) {
+        throw new Error('RNGoogleSignin: Missing property `showPlayServicesUpdateDialog` in options object for `hasPlayServices`');
       }
-      return RNGoogleSignin.playServicesAvailable(params.showPlayServicesUpdateDialog);
+      return RNGoogleSignin.playServicesAvailable(options.showPlayServicesUpdateDialog);
     }
   }
 
-  configure(params = {}) {
-    if (IS_IOS && !params.iosClientId) {
-      throw new Error('RNGoogleSignin: Missing iOS app ClientID');
-    }
-
-    if (params.offlineAccess && !params.webClientId) {
+  configure(options = {}) {
+    if (options.offlineAccess && !options.webClientId) {
       throw new Error('RNGoogleSignin: offline use requires server web ClientID');
     }
 
-    this.configPromise = RNGoogleSignin.configure(params);
+    this.configPromise = RNGoogleSignin.configure(options);
   }
 
   async signInSilently() {


### PR DESCRIPTION
We can get `clientID` from `Google-Service.plist` directly so there is no need for additional iOS specific configuration when calling `configure()`.

Additionally, since we are checking if `Google-Service.plist` is missing, we can inform users about misconfiguration. Hopefully this reduces setup pain a bit.

Updated README and fixed wording here and there.