### PR TITLE
add isSignedIn method and SIGN_IN_REQUIRED error code

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ getCurrentUserInfo = async () => {
 
 #### `isSignedIn()`
 
-This method may be used to find out whether some user is currently signed in. It returns a promise which resolves with a boolean value (it never rejects). In the native layer, this is a synchronous call.
+This method may be used to find out whether some user is currently signed in. It returns a promise which resolves with a boolean value (it never rejects). In the native layer, this is a synchronous call. This means that it will resolve even when the device is offline. Note that it may happen that `isSignedIn()` resolves to true and calling `signInSilently()` rejects with an error (eg. due to a network issue).
 
 ```js
 isSignedIn = async () => {

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ import { GoogleSignin, GoogleSigninButton, statusCodes } from 'react-native-goog
 
 #### `configure(options)`
 
-It is mandatory to call this method before attempting to call `signIn()` and `signInSilently()`. This method is sync meaning you can call `signIn` / `signInSilently` right after it. In typical scenarios, `configure` needs to be called only once, after your app starts.
+It is mandatory to call this method before attempting to call `signIn()` and `signInSilently()`. This method is sync meaning you can call `signIn` / `signInSilently` right after it. In typical scenarios, `configure` needs to be called only once, after your app starts. In the native layer, this is a synchronous call.
 
 Example usage with for default options: you get user email and basic profile info.
 
@@ -139,13 +139,28 @@ May be called eg. in the `componentDidMount` of your main component. This method
 To see how to handle errors read [`signIn()` method](#signin)
 
 ```js
-getCurrentUser = async () => {
+getCurrentUserInfo = async () => {
   try {
     const userInfo = await GoogleSignin.signInSilently();
     this.setState({ userInfo });
   } catch (error) {
-    console.error(error);
+    if (error.code === statusCodes.SIGN_IN_REQUIRED) {
+      // user has not signed in yet
+    } else {
+      // some other error
+    }
   }
+};
+```
+
+#### `isSignedIn()`
+
+This method may be used to find out whether some user is currently signed in. It returns a promise which resolves with a boolean value (it never rejects). In the native layer, this is a synchronous call.
+
+```js
+isSignedIn = async () => {
+  const isSignedIn = await GoogleSignin.isSignedIn();
+  this.setState({ isLoginScreenPresented: !isSignedIn });
 };
 ```
 
@@ -209,6 +224,7 @@ These are useful when determining which kind of error has occured during sign in
 | ----------------------------- | ------------------------------------------------------------------------------------------------------------- |
 | `SIGN_IN_CANCELLED`           | When user cancels the sign in flow                                                                            |
 | `IN_PROGRESS`                 | Trying to invoke another sign in flow (or any of the other operations) when previous one has not yet finished |
+| `SIGN_IN_REQUIRED`            | Useful for use with `signInSilently()` - no user has signed in yet                                            |
 | `PLAY_SERVICES_NOT_AVAILABLE` | Play services are not available or outdated, this can only happen on Android                                  |
 
 [Example how to use `statusCodes`](#signin).

--- a/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
+++ b/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
@@ -240,6 +240,12 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
                 });
     }
 
+    @ReactMethod
+    public void isSignedIn(Promise promise) {
+        boolean isSignedIn = GoogleSignIn.getLastSignedInAccount(getReactApplicationContext()) != null;
+        promise.resolve(isSignedIn);
+    }
+
     private static class AccessTokenRetrievalTask extends AsyncTask<WritableMap, Void, WritableMap> {
 
         private WeakReference<RNGoogleSigninModule> weakModuleRef;

--- a/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
+++ b/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
@@ -27,6 +27,7 @@ import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.gms.common.SignInButton;
 import com.google.android.gms.common.api.ApiException;
+import com.google.android.gms.common.api.CommonStatusCodes;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
 
@@ -72,6 +73,7 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
         constants.put("BUTTON_COLOR_LIGHT", SignInButton.COLOR_LIGHT);
         constants.put("BUTTON_COLOR_DARK", SignInButton.COLOR_DARK);
         constants.put("SIGN_IN_CANCELLED", String.valueOf(GoogleSignInStatusCodes.SIGN_IN_CANCELLED));
+        constants.put("SIGN_IN_REQUIRED", String.valueOf(CommonStatusCodes.SIGN_IN_REQUIRED));
         constants.put("IN_PROGRESS", ASYNC_OP_IN_PROGRESS);
         constants.put(PLAY_SERVICES_NOT_AVAILABLE, PLAY_SERVICES_NOT_AVAILABLE);
         return constants;

--- a/example/index.js
+++ b/example/index.js
@@ -30,8 +30,10 @@ class GoogleSigninSampleApp extends Component {
       const userInfo = await GoogleSignin.signInSilently();
       this.setState({ userInfo, error: null });
     } catch (error) {
+      const errorMessage =
+        error.code === statusCodes.SIGN_IN_REQUIRED ? 'Please sign in :)' : error.message;
       this.setState({
-        error,
+        error: errorMessage,
       });
     }
   }
@@ -92,13 +94,11 @@ class GoogleSigninSampleApp extends Component {
 
   renderError() {
     const { error } = this.state;
-    return (
-      !!error && (
-        <Text>
-          {error.toString()} code: {error.code}
-        </Text>
-      )
-    );
+    if (!error) {
+      return null;
+    }
+    const text = `${error.toString()} ${error.code ? error.code : ''}`;
+    return <Text>{text}</Text>;
   }
 
   _signIn = async () => {

--- a/example/index.js
+++ b/example/index.js
@@ -1,12 +1,5 @@
 import React, { Component } from 'react';
-import {
-  AppRegistry,
-  StyleSheet,
-  Text,
-  View,
-  TouchableOpacity,
-  Alert,
-} from 'react-native';
+import { AppRegistry, StyleSheet, Text, View, Alert, Button } from 'react-native';
 
 import { GoogleSignin, GoogleSigninButton, statusCodes } from 'react-native-google-signin';
 import config from './config';
@@ -45,35 +38,56 @@ class GoogleSigninSampleApp extends Component {
 
   render() {
     const { userInfo } = this.state;
-    if (!userInfo) {
-      return (
-        <View style={styles.container}>
-          <GoogleSigninButton
-            style={{ width: 212, height: 48 }}
-            size={GoogleSigninButton.Size.Standard}
-            color={GoogleSigninButton.Color.Auto}
-            onPress={this._signIn}
-          />
-          {this.renderError()}
-        </View>
-      );
-    } else {
-      return (
-        <View style={styles.container}>
-          <Text style={{ fontSize: 18, fontWeight: 'bold', marginBottom: 20 }}>
-            Welcome {userInfo.user.name}
-          </Text>
-          <Text>Your user info: {JSON.stringify(userInfo.user)}</Text>
 
-          <TouchableOpacity onPress={this._signOut}>
-            <View style={{ marginTop: 50, padding: 20 }}>
-              <Text>Log out</Text>
-            </View>
-          </TouchableOpacity>
-          {this.renderError()}
-        </View>
-      );
-    }
+    const body = userInfo ? this.renderUserInfo() : this.renderSignInButton();
+    return (
+      <View style={[styles.container, { flex: 1 }]}>
+        {this.renderIsSignedIn()}
+        {body}
+      </View>
+    );
+  }
+
+  renderIsSignedIn() {
+    return (
+      <Button
+        onPress={async () => {
+          const isSignedIn = await GoogleSignin.isSignedIn();
+          Alert.alert(String(isSignedIn));
+        }}
+        title="is user signed in?"
+      />
+    );
+  }
+
+  renderUserInfo() {
+    const { userInfo } = this.state;
+
+    return (
+      <View style={styles.container}>
+        <Text style={{ fontSize: 18, fontWeight: 'bold', marginBottom: 20 }}>
+          Welcome {userInfo.user.name}
+        </Text>
+        <Text>Your user info: {JSON.stringify(userInfo.user)}</Text>
+
+        <Button onPress={this._signOut} title="Log out" />
+        {this.renderError()}
+      </View>
+    );
+  }
+
+  renderSignInButton() {
+    return (
+      <View style={styles.container}>
+        <GoogleSigninButton
+          style={{ width: 212, height: 48 }}
+          size={GoogleSigninButton.Size.Standard}
+          color={GoogleSigninButton.Color.Auto}
+          onPress={this._signIn}
+        />
+        {this.renderError()}
+      </View>
+    );
   }
 
   renderError() {
@@ -95,12 +109,12 @@ class GoogleSigninSampleApp extends Component {
     } catch (error) {
       if (error.code === statusCodes.SIGN_IN_CANCELLED) {
         // sign in was cancelled
-        alert('cancelled');
+        Alert.alert('cancelled');
       } else if (error.code === statusCodes.IN_PROGRESS) {
         // operation in progress already
-        alert('in progress');
+        Alert.alert('in progress');
       } else if (error.code === statusCodes.PLAY_SERVICES_NOT_AVAILABLE) {
-        alert('play services not available or outdated');
+        Alert.alert('play services not available or outdated');
       } else {
         Alert.alert('Something went wrong', error.toString());
         this.setState({
@@ -126,7 +140,6 @@ class GoogleSigninSampleApp extends Component {
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
     backgroundColor: '#F5FCFF',

--- a/ios/RNGoogleSignin/RNGoogleSignin.m
+++ b/ios/RNGoogleSignin/RNGoogleSignin.m
@@ -29,6 +29,7 @@ static NSString *const kClientIdKey = @"CLIENT_ID";
            @"BUTTON_COLOR_LIGHT": @(kGIDSignInButtonColorSchemeLight),
            @"BUTTON_COLOR_DARK": @(kGIDSignInButtonColorSchemeDark),
            @"SIGN_IN_CANCELLED": [@(kGIDSignInErrorCodeCanceled) stringValue],
+           @"SIGN_IN_REQUIRED": [@(kGIDSignInErrorCodeHasNoAuthInKeychain) stringValue],
            @"IN_PROGRESS": ASYNC_OP_IN_PROGRESS,
            PLAY_SERVICES_NOT_AVAILABLE: PLAY_SERVICES_NOT_AVAILABLE // this never happens on iOS
            };

--- a/ios/RNGoogleSignin/RNGoogleSignin.m
+++ b/ios/RNGoogleSignin/RNGoogleSignin.m
@@ -126,6 +126,14 @@ RCT_REMAP_METHOD(revokeAccess,
   [[GIDSignIn sharedInstance] disconnect];
 }
 
+RCT_REMAP_METHOD(isSignedIn,
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
+{
+  BOOL isSignedIn = [[GIDSignIn sharedInstance] hasAuthInKeychain];
+  resolve([NSNumber numberWithBool:isSignedIn]);
+}
+
 - (void)signIn:(GIDSignIn *)signIn didSignInForUser:(GIDGoogleUser *)user withError:(NSError *)error {
   if (error) {
     [self rejectWithSigninError: error];

--- a/src/GoogleSignin.js
+++ b/src/GoogleSignin.js
@@ -10,6 +10,7 @@ export const statusCodes = {
   SIGN_IN_CANCELLED: RNGoogleSignin.SIGN_IN_CANCELLED,
   IN_PROGRESS: RNGoogleSignin.IN_PROGRESS,
   PLAY_SERVICES_NOT_AVAILABLE: RNGoogleSignin.PLAY_SERVICES_NOT_AVAILABLE,
+  SIGN_IN_REQUIRED: RNGoogleSignin.SIGN_IN_REQUIRED,
 };
 
 class GoogleSignin {

--- a/src/GoogleSignin.js
+++ b/src/GoogleSignin.js
@@ -25,7 +25,9 @@ class GoogleSignin {
       return true;
     } else {
       if (options && options.showPlayServicesUpdateDialog === undefined) {
-        throw new Error('RNGoogleSignin: Missing property `showPlayServicesUpdateDialog` in options object for `hasPlayServices`');
+        throw new Error(
+          'RNGoogleSignin: Missing property `showPlayServicesUpdateDialog` in options object for `hasPlayServices`'
+        );
       }
       return RNGoogleSignin.playServicesAvailable(options.showPlayServicesUpdateDialog);
     }
@@ -50,6 +52,10 @@ class GoogleSignin {
 
   async revokeAccess() {
     return RNGoogleSignin.revokeAccess();
+  }
+
+  async isSignedIn() {
+    return RNGoogleSignin.isSignedIn();
   }
 }
 


### PR DESCRIPTION
This PR adds `isSignedIn` function that returns a boolean and may be, in some cases, better suited than calling `signInSilently` and seeing if it resolves / rejects.

I'd like to hereby that the author of a similar PR to the Flutter google sign in plugin, who did some background research that I could pick up: https://github.com/flutter/plugins/pull/501

Also, I have added `SIGN_IN_REQUIRED` error code which is useful together with `signInSilently`, as documented.