### PR TITLE
add more context to error messages

### DIFF
--- a/android/src/main/java/co/apptailor/googlesignin/PromiseWrapper.java
+++ b/android/src/main/java/co/apptailor/googlesignin/PromiseWrapper.java
@@ -7,35 +7,46 @@ import com.facebook.react.bridge.Promise;
 import static co.apptailor.googlesignin.RNGoogleSigninModule.MODULE_NAME;
 
 public class PromiseWrapper {
-    private Promise _promise;
+    private Promise promise;
+    private String nameOfCallInProgress;
 
 
-    public boolean setPromiseWithInProgressCheck(Promise promise) {
+    public boolean setPromiseWithInProgressCheck(Promise promise, String fromCallsite) {
         boolean success = false;
-        if (_promise == null) {
-            _promise = promise;
+        if (this.promise == null) {
+            this.promise = promise;
+            nameOfCallInProgress = fromCallsite;
             success = true;
         }
         return success;
     }
 
     public void resolve(Object value) {
-        if (_promise == null) {
+        if (promise == null) {
             Log.w(MODULE_NAME, "cannot resolve promise because it's null");
             return;
         }
 
-        _promise.resolve(value);
-        _promise = null;
+        promise.resolve(value);
+        resetMembers();
     }
 
     public void reject(String code, String message) {
-        if (_promise == null) {
+        if (promise == null) {
             Log.w(MODULE_NAME, "cannot reject promise because it's null");
             return;
         }
 
-        _promise.reject(code, message);
-        _promise = null;
+        promise.reject(code, message);
+        resetMembers();
+    }
+
+    public String getNameOfCallInProgress(){
+        return nameOfCallInProgress;
+    }
+
+    private void resetMembers() {
+        promise = null;
+        nameOfCallInProgress = null;
     }
 }

--- a/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
+++ b/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
@@ -127,7 +127,7 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
         }
         boolean wasPromiseSet = promiseWrapper.setPromiseWithInProgressCheck(promise);
         if (!wasPromiseSet) {
-            rejectWithAsyncOperationStillInProgress(promise);
+            rejectWithAsyncOperationStillInProgress(promise, "signInSilently");
             return;
         }
 
@@ -157,7 +157,8 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
             new AccessTokenRetrievalTask(this).execute(params);
         } catch (ApiException e) {
             int code = e.getStatusCode();
-            promiseWrapper.reject(String.valueOf(code), GoogleSignInStatusCodes.getStatusCodeString(code));
+            String errorDescription = GoogleSignInStatusCodes.getStatusCodeString(code);
+            promiseWrapper.reject(String.valueOf(code), errorDescription);
         }
     }
 
@@ -177,7 +178,7 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
 
         boolean wasPromiseSet = promiseWrapper.setPromiseWithInProgressCheck(promise);
         if (!wasPromiseSet) {
-            rejectWithAsyncOperationStillInProgress(promise);
+            rejectWithAsyncOperationStillInProgress(promise, "signIn");
             return;
         }
 
@@ -222,7 +223,8 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
             promise.resolve(true);
         } else {
             int code = getExceptionCode(task);
-            promise.reject(String.valueOf(code), GoogleSignInStatusCodes.getStatusCodeString(code));
+            String errorDescription = GoogleSignInStatusCodes.getStatusCodeString(code);
+            promise.reject(String.valueOf(code), errorDescription);
         }
     }
 
@@ -290,8 +292,9 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
         promise.reject(MODULE_NAME, "apiClient is null - call configure first");
     }
 
-    private void rejectWithAsyncOperationStillInProgress(Promise promise) {
-        promise.reject(ASYNC_OP_IN_PROGRESS, "cannot set promise - some async operation is still in progress");
+    private void rejectWithAsyncOperationStillInProgress(Promise promise, String callSiteName) {
+        promise.reject(ASYNC_OP_IN_PROGRESS, "Cannot set promise. You've called " + callSiteName + " while some async operation is already in progress and has not completed yet. " +
+                "Make sure you're not repeatedly calling signInSilently and signIn from your JS code while the previous call has not completed yet.");
     }
 
 }

--- a/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
+++ b/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
@@ -125,9 +125,10 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
             rejectWithNullClientError(promise);
             return;
         }
-        boolean wasPromiseSet = promiseWrapper.setPromiseWithInProgressCheck(promise);
+        String methodName = "signInSilently";
+        boolean wasPromiseSet = promiseWrapper.setPromiseWithInProgressCheck(promise, methodName);
         if (!wasPromiseSet) {
-            rejectWithAsyncOperationStillInProgress(promise, "signInSilently");
+            rejectWithAsyncOperationStillInProgress(promise, methodName);
             return;
         }
 
@@ -175,10 +176,10 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
             promise.reject(MODULE_NAME, "activity is null");
             return;
         }
-
-        boolean wasPromiseSet = promiseWrapper.setPromiseWithInProgressCheck(promise);
+        String methodName = "signIn";
+        boolean wasPromiseSet = promiseWrapper.setPromiseWithInProgressCheck(promise, methodName);
         if (!wasPromiseSet) {
-            rejectWithAsyncOperationStillInProgress(promise, "signIn");
+            rejectWithAsyncOperationStillInProgress(promise, methodName);
             return;
         }
 
@@ -292,8 +293,8 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
         promise.reject(MODULE_NAME, "apiClient is null - call configure first");
     }
 
-    private void rejectWithAsyncOperationStillInProgress(Promise promise, String callSiteName) {
-        promise.reject(ASYNC_OP_IN_PROGRESS, "Cannot set promise. You've called " + callSiteName + " while some async operation is already in progress and has not completed yet. " +
+    private void rejectWithAsyncOperationStillInProgress(Promise promise, String requestedOperation) {
+        promise.reject(ASYNC_OP_IN_PROGRESS, "Cannot set promise. You've called \"" + requestedOperation + "\" while \"" + promiseWrapper.getNameOfCallInProgress() + "\" is already in progress and has not completed yet. " +
                 "Make sure you're not repeatedly calling signInSilently and signIn from your JS code while the previous call has not completed yet.");
     }
 

--- a/ios/RNGoogleSignin/RNGSPromiseWrapper.h
+++ b/ios/RNGoogleSignin/RNGSPromiseWrapper.h
@@ -12,9 +12,10 @@
 
 @interface RNGSPromiseWrapper : NSObject
 
--(BOOL) setPromiseWithInProgressCheck:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject;
--(void) resolve: (id) result;
--(void) reject:(NSString *)message withError:(NSError *)error;
+-(BOOL)setPromiseWithInProgressCheck:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject fromCallSite: (NSString*) callsite;
+-(void)resolve: (id) result;
+-(void)reject:(NSString *)message withError:(NSError *)error;
+@property (readonly, assign) NSString *nameOfCallInProgress;
 
 @end
 

--- a/ios/RNGoogleSignin/RNGSPromiseWrapper.m
+++ b/ios/RNGoogleSignin/RNGSPromiseWrapper.m
@@ -14,32 +14,33 @@
 
 @property (nonatomic, strong) RCTPromiseResolveBlock promiseResolve;
 @property (nonatomic, strong) RCTPromiseRejectBlock promiseReject;
+@property (readwrite, assign) NSString *nameOfCallInProgress;
 
 @end
 
 @implementation RNGSPromiseWrapper
 
--(BOOL) setPromiseWithInProgressCheck: (RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject {
+-(BOOL)setPromiseWithInProgressCheck: (RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject fromCallSite:(NSString *) callsite {
   BOOL success = NO;
   if (!self.promiseResolve) {
     self.promiseResolve = resolve;
     self.promiseReject = reject;
+    self.nameOfCallInProgress = callsite;
     success = YES;
   }
   return success;
 }
 
--(void) resolve: (id) result {
+-(void)resolve: (id) result {
   if (self.promiseResolve == nil) {
     NSLog(@"cannot resolve promise because it's null");
     return;
   }
   self.promiseResolve(result);
-  self.promiseResolve = nil;
-  self.promiseReject = nil;
+  [self resetMembers];
 }
 
--(void) reject:(NSString *)message withError:(NSError *)error {
+-(void)reject:(NSString *)message withError:(NSError *)error {
   if (self.promiseResolve == nil) {
     NSLog(@"cannot resolve promise because it's null");
     return;
@@ -48,9 +49,13 @@
   NSString* errorMessage = [NSString stringWithFormat:@"RNGoogleSignInError: %@, %@", message, error.description];
   
   self.promiseReject(errorCode, errorMessage, error);
-  
+  [self resetMembers];
+}
+
+-(void)resetMembers {
   self.promiseResolve = nil;
   self.promiseReject = nil;
+  self.nameOfCallInProgress = nil;
 }
 
 

--- a/ios/RNGoogleSignin/RNGoogleSignin.m
+++ b/ios/RNGoogleSignin/RNGoogleSignin.m
@@ -89,7 +89,7 @@ RCT_REMAP_METHOD(signInSilently,
 {
   BOOL wasPromiseSet = [self.promiseWrapper setPromiseWithInProgressCheck:resolve rejecter:reject];
   if (!wasPromiseSet) {
-    [self rejectWithAsyncOperationStillInProgress: reject];
+    [self rejectWithAsyncOperationStillInProgress: reject fromCallSite:@"signInSilently"];
     return;
   }
   [[GIDSignIn sharedInstance] signInSilently];
@@ -101,7 +101,7 @@ RCT_REMAP_METHOD(signIn,
 {
   BOOL wasPromiseSet = [self.promiseWrapper setPromiseWithInProgressCheck:resolve rejecter:reject];
   if (!wasPromiseSet) {
-    [self rejectWithAsyncOperationStillInProgress: reject];
+    [self rejectWithAsyncOperationStillInProgress: reject fromCallSite:@"signIn"];
     return;
   }
   [[GIDSignIn sharedInstance] signIn];
@@ -121,7 +121,7 @@ RCT_REMAP_METHOD(revokeAccess,
 {
   BOOL wasPromiseSet = [self.promiseWrapper setPromiseWithInProgressCheck:resolve rejecter:reject];
   if (!wasPromiseSet) {
-    [self rejectWithAsyncOperationStillInProgress: reject];
+    [self rejectWithAsyncOperationStillInProgress: reject fromCallSite:@"revokeAccess"];
     return;
   }
   [[GIDSignIn sharedInstance] disconnect];
@@ -168,7 +168,7 @@ RCT_REMAP_METHOD(isSignedIn,
 }
 
 - (void)rejectWithSigninError: (NSError *) error {
-  NSString * errorMessage = @"Unknown error when signing in.";
+  NSString *errorMessage = @"Unknown error when signing in.";
   switch (error.code) {
     case kGIDSignInErrorCodeUnknown:
       errorMessage = @"Unknown error when signing in.";
@@ -206,8 +206,9 @@ RCT_REMAP_METHOD(isSignedIn,
   [viewController dismissViewControllerAnimated:true completion:nil];
 }
 
-- (void)rejectWithAsyncOperationStillInProgress: (RCTPromiseRejectBlock)reject {
-  reject(ASYNC_OP_IN_PROGRESS, @"cannot set promise - some async operation is still in progress", nil);
+- (void)rejectWithAsyncOperationStillInProgress: (RCTPromiseRejectBlock)reject fromCallSite:(NSString *) callSiteName {
+  NSString *msg = [NSString stringWithFormat:@"Cannot set promise. You've called %@ while some async operation is already in progress and has not completed yet. Make sure you're not repeatedly calling signInSilently, signIn or revokeAccess from your JS code while the previous call has not completed yet.", callSiteName];
+  reject(ASYNC_OP_IN_PROGRESS, msg, nil);
 }
 
 + (BOOL)application:(UIApplication *)application openURL:(NSURL *)url

--- a/ios/RNGoogleSignin/RNGoogleSignin.m
+++ b/ios/RNGoogleSignin/RNGoogleSignin.m
@@ -87,9 +87,10 @@ RCT_REMAP_METHOD(signInSilently,
                  currentUserAsyncResolve:(RCTPromiseResolveBlock)resolve
                  currentUserAsyncReject:(RCTPromiseRejectBlock)reject)
 {
-  BOOL wasPromiseSet = [self.promiseWrapper setPromiseWithInProgressCheck:resolve rejecter:reject];
+  NSString* methodName = @"signInSilently";
+  BOOL wasPromiseSet = [self.promiseWrapper setPromiseWithInProgressCheck:resolve rejecter:reject fromCallSite:methodName];
   if (!wasPromiseSet) {
-    [self rejectWithAsyncOperationStillInProgress: reject fromCallSite:@"signInSilently"];
+    [self rejectWithAsyncOperationStillInProgress: reject requestedOperation:methodName];
     return;
   }
   [[GIDSignIn sharedInstance] signInSilently];
@@ -99,9 +100,10 @@ RCT_REMAP_METHOD(signIn,
                  signInResolve:(RCTPromiseResolveBlock)resolve
                  signInReject:(RCTPromiseRejectBlock)reject)
 {
-  BOOL wasPromiseSet = [self.promiseWrapper setPromiseWithInProgressCheck:resolve rejecter:reject];
+  NSString* methodName = @"signIn";
+  BOOL wasPromiseSet = [self.promiseWrapper setPromiseWithInProgressCheck:resolve rejecter:reject fromCallSite:methodName];
   if (!wasPromiseSet) {
-    [self rejectWithAsyncOperationStillInProgress: reject fromCallSite:@"signIn"];
+    [self rejectWithAsyncOperationStillInProgress: reject requestedOperation:methodName];
     return;
   }
   [[GIDSignIn sharedInstance] signIn];
@@ -119,9 +121,10 @@ RCT_REMAP_METHOD(revokeAccess,
                  revokeAccessResolve:(RCTPromiseResolveBlock)resolve
                  revokeAccessReject:(RCTPromiseRejectBlock)reject)
 {
-  BOOL wasPromiseSet = [self.promiseWrapper setPromiseWithInProgressCheck:resolve rejecter:reject];
+  NSString* methodName = @"revokeAccess";
+  BOOL wasPromiseSet = [self.promiseWrapper setPromiseWithInProgressCheck:resolve rejecter:reject fromCallSite:methodName];
   if (!wasPromiseSet) {
-    [self rejectWithAsyncOperationStillInProgress: reject fromCallSite:@"revokeAccess"];
+    [self rejectWithAsyncOperationStillInProgress: reject requestedOperation:methodName];
     return;
   }
   [[GIDSignIn sharedInstance] disconnect];
@@ -206,8 +209,8 @@ RCT_REMAP_METHOD(isSignedIn,
   [viewController dismissViewControllerAnimated:true completion:nil];
 }
 
-- (void)rejectWithAsyncOperationStillInProgress: (RCTPromiseRejectBlock)reject fromCallSite:(NSString *) callSiteName {
-  NSString *msg = [NSString stringWithFormat:@"Cannot set promise. You've called %@ while some async operation is already in progress and has not completed yet. Make sure you're not repeatedly calling signInSilently, signIn or revokeAccess from your JS code while the previous call has not completed yet.", callSiteName];
+- (void)rejectWithAsyncOperationStillInProgress: (RCTPromiseRejectBlock)reject requestedOperation:(NSString *) callSiteName {
+  NSString *msg = [NSString stringWithFormat:@"Cannot set promise. You've called \"%@\" while \"%@\" is already in progress and has not completed yet. Make sure you're not repeatedly calling signInSilently, signIn or revokeAccess from your JS code while the previous call has not completed yet.", callSiteName, self.promiseWrapper.nameOfCallInProgress];
   reject(ASYNC_OP_IN_PROGRESS, msg, nil);
 }
 


### PR DESCRIPTION
when some operation is in progress and another thus fails, we log names of both which should help with debugging significantly 


maybe we can derive the call site: https://stackoverflow.com/questions/421280/how-do-i-find-the-caller-of-a-method-using-stacktrace-or-reflection https://stackoverflow.com/questions/1451342/objective-c-find-caller-of-method - I did not do that since it's too opaque