### PR TITLE
Don't crash when native module is missing.

### DIFF
--- a/src/GoogleSignin.js
+++ b/src/GoogleSignin.js
@@ -6,23 +6,28 @@ const { RNGoogleSignin } = NativeModules;
 
 const IS_IOS = Platform.OS === 'ios';
 
+const NativeModuleLoaded = RNGoogleSignin !== undefined;
+
+function ensureNativeNoduleLoaded() {
+  if (!NativeModuleLoaded) {
+    throw new Error(
+      'RN GoogleSignin native module is not correctly linked. Please read the readme, setup and troubleshooting instructions carefully or try manual linking.'
+    );
+  }
+}
+
 class GoogleSignin {
   configPromise;
 
-  constructor() {
-    if (__DEV__ && !RNGoogleSignin) {
-      console.error(
-        'RN GoogleSignin native module is not correctly linked. Please read the readme, setup and troubleshooting instructions carefully or try manual linking.'
-      );
-    }
-  }
-
   async signIn() {
+    ensureNativeModuleLoaded();
     await this.configPromise;
     return await RNGoogleSignin.signIn();
   }
 
   async hasPlayServices(options = { showPlayServicesUpdateDialog: true }) {
+    ensureNativeModuleLoaded();
+
     if (IS_IOS) {
       return true;
     } else {
@@ -36,6 +41,8 @@ class GoogleSignin {
   }
 
   configure(options = {}) {
+    ensureNativeModuleLoaded();
+
     if (options.offlineAccess && !options.webClientId) {
       throw new Error('RNGoogleSignin: offline use requires server web ClientID');
     }
@@ -44,26 +51,34 @@ class GoogleSignin {
   }
 
   async signInSilently() {
+    ensureNativeModuleLoaded();
+
     await this.configPromise;
     return RNGoogleSignin.signInSilently();
   }
 
   async signOut() {
+    ensureNativeModuleLoaded();
+
     return RNGoogleSignin.signOut();
   }
 
   async revokeAccess() {
+    ensureNativeModuleLoaded();
+
     return RNGoogleSignin.revokeAccess();
   }
 
   async isSignedIn() {
+    ensureNativeModuleLoaded();
+    
     return RNGoogleSignin.isSignedIn();
   }
 }
 
 export const GoogleSigninSingleton = new GoogleSignin();
 
-export const statusCodes = {
+export const statusCodes = NativeModuleLoaded ? {
   SIGN_IN_CANCELLED: RNGoogleSignin.SIGN_IN_CANCELLED,
   IN_PROGRESS: RNGoogleSignin.IN_PROGRESS,
   PLAY_SERVICES_NOT_AVAILABLE: RNGoogleSignin.PLAY_SERVICES_NOT_AVAILABLE,


### PR DESCRIPTION
I want to use the Google Signin on Android, but not on iOS, so on IOS, I am not linking the libraries.

Result: I have this crash: ```Cannot read property 'SIGN_IN_CANCELLED' of undefined``` as soon as I try to import from `react-native-google-signin`.

With this extra check, using the library in the way I described becomes much easier.