### PR TITLE
rename googlePlayServicesVersion to googlePlayServicesAuthVersion

### DIFF
--- a/android-guide.md
+++ b/android-guide.md
@@ -18,17 +18,9 @@ You need the following packages
 
 Please note that this package requires android gradle plugin of version >= 3, which in turn requires at least gradle 4.1. Android studio should be able to do the upgrade for you.
 
-- run `react-native link react-native-google-signin`
+1 . run `react-native link react-native-google-signin`
 
-- In `android/settings.gradle` you should have
-
-```gradle
-...
-include ':react-native-google-signin', ':app'
-project(':react-native-google-signin').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-google-signin/android')
-```
-
-- Update `android/build.gradle` with
+2 . Update `android/build.gradle` with
 
 ```gradle
 buildscript {
@@ -59,7 +51,7 @@ allprojects {
 }
 ```
 
-- Update `android/app/build.gradle` with
+3 . Update `android/app/build.gradle` with
 
 ```gradle
 ...
@@ -73,7 +65,17 @@ dependencies {
 apply plugin: 'com.google.gms.google-services' // <--- this should be the last line
 ```
 
-- Register Module (in MainApplication.java)
+4. Check that `react-native link` linked the native module
+
+- in `android/settings.gradle` you should have
+
+```gradle
+...
+include ':react-native-google-signin', ':app'
+project(':react-native-google-signin').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-google-signin/android')
+```
+
+- in MainApplication.java you should have
 
 ```java
 import co.apptailor.googlesignin.RNGoogleSigninPackage;  // <--- import
@@ -86,7 +88,7 @@ public class MainApplication extends Application implements ReactApplication {
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
           new MainReactPackage(),
-          new RNGoogleSigninPackage() // <-- add this
+          new RNGoogleSigninPackage() // <-- this needs to be in the list
       );
     }
   ......

--- a/android-guide.md
+++ b/android-guide.md
@@ -75,7 +75,7 @@ include ':react-native-google-signin', ':app'
 project(':react-native-google-signin').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-google-signin/android')
 ```
 
-- in MainApplication.java you should have
+- in `MainApplication.java` you should have
 
 ```java
 import co.apptailor.googlesignin.RNGoogleSigninPackage;  // <--- import

--- a/android-guide.md
+++ b/android-guide.md
@@ -38,7 +38,7 @@ buildscript {
         compileSdkVersion = 27
         targetSdkVersion = 26
         supportLibVersion = "27.1.1"
-        googlePlayServicesVersion = "15.0.1" // <--- use this version or newer
+        googlePlayServicesAuthVersion = "15.0.1" // <--- use this version or newer
     }
 ...
     dependencies {
@@ -68,7 +68,6 @@ dependencies {
     implementation "com.android.support:appcompat-v7:23.0.1"
     implementation "com.facebook.react:react-native:+"
     implementation(project(":react-native-google-signin"))
-    implementation 'com.google.android.gms:play-services-auth:15.0.0' // should be at least 15.0.0 to work with the most recent APIs
 }
 
 apply plugin: 'com.google.gms.google-services' // <--- this should be the last line

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,6 +42,6 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation "com.android.support:appcompat-v7:${safeExtGet('supportLibVersion', '26.1.0')}"
-    implementation "com.google.android.gms:play-services-auth:${safeExtGet('googlePlayServicesVersion', '+')}"
+    implementation "com.google.android.gms:play-services-auth:${safeExtGet('googlePlayServicesAuthVersion', '16.0.1')}"
     implementation "com.facebook.react:react-native:+"
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -138,7 +138,6 @@ android {
 
 dependencies {
     implementation project(':react-native-google-signin')
-    implementation 'com.google.android.gms:play-services-auth:16.0.1'
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
     implementation "com.facebook.react:react-native:+"  // From node_modules

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         compileSdkVersion = 27
         targetSdkVersion = 26
         supportLibVersion = "27.1.1"
-        googlePlayServicesVersion = "16.0.1"
+        googlePlayServicesAuthVersion = "16.0.1"
     }
     repositories {
         google()


### PR DESCRIPTION
**breaking** renames googlePlayServicesVersion to googlePlayServicesAuthVersion

motivation: there are many google play services libs, as seen here, with different versions available https://developers.google.com/android/guides/setup

This allows to specify the version of the one we depend on, which is `com.google.android.gms:play-services-auth` and does not collide with different google play services libs used for example in [react-native-device-info](https://github.com/rebeccahughes/react-native-device-info/blob/4b4a2125612995e8b091d6e539b92abd9720f46c/android/build.gradle#L30)