### PR TITLE
synchronize access to promise wrapper

### DIFF
--- a/android/src/main/java/co/apptailor/googlesignin/PromiseWrapper.java
+++ b/android/src/main/java/co/apptailor/googlesignin/PromiseWrapper.java
@@ -12,51 +12,45 @@ public class PromiseWrapper {
 
 
     public boolean setPromiseWithInProgressCheck(Promise promise, String fromCallsite) {
-        synchronized (this) {
-            boolean success = false;
-            if (this.promise == null) {
-                this.promise = promise;
-                nameOfCallInProgress = fromCallsite;
-                success = true;
-            }
-            return success;
+        if (this.promise != null) {
+            return false;
         }
+        this.promise = promise;
+        nameOfCallInProgress = fromCallsite;
+        return true;
     }
 
     public void resolve(Object value) {
-        synchronized (this) {
-            if (promise == null) {
-                Log.w(MODULE_NAME, "cannot resolve promise because it's null");
-                return;
-            }
-
-            promise.resolve(value);
-            resetMembers();
+        Promise resolver = promise;
+        if (resolver == null) {
+            Log.w(MODULE_NAME, "cannot resolve promise because it's null");
+            return;
         }
+
+        resetMembers();
+        resolver.resolve(value);
     }
 
     public void reject(String code, Throwable throwable) {
-        synchronized (this) {
-            if (promise == null) {
-                Log.w(MODULE_NAME, "cannot reject promise because it's null");
-                return;
-            }
-
-            promise.reject(code, throwable.getLocalizedMessage(), throwable);
-            resetMembers();
+        Promise rejecter = promise;
+        if (rejecter == null) {
+            Log.w(MODULE_NAME, "cannot reject promise because it's null");
+            return;
         }
+
+        resetMembers();
+        rejecter.reject(code, throwable.getLocalizedMessage(), throwable);
     }
 
     public void reject(String code, String message) {
-        synchronized (this) {
-            if (promise == null) {
-                Log.w(MODULE_NAME, "cannot reject promise because it's null");
-                return;
-            }
-
-            promise.reject(code, message);
-            resetMembers();
+        Promise rejecter = promise;
+        if (rejecter == null) {
+            Log.w(MODULE_NAME, "cannot reject promise because it's null");
+            return;
         }
+
+        resetMembers();
+        rejecter.reject(code, message);
     }
 
     public String getNameOfCallInProgress(){

--- a/android/src/main/java/co/apptailor/googlesignin/PromiseWrapper.java
+++ b/android/src/main/java/co/apptailor/googlesignin/PromiseWrapper.java
@@ -12,43 +12,51 @@ public class PromiseWrapper {
 
 
     public boolean setPromiseWithInProgressCheck(Promise promise, String fromCallsite) {
-        boolean success = false;
-        if (this.promise == null) {
-            this.promise = promise;
-            nameOfCallInProgress = fromCallsite;
-            success = true;
+        synchronized (this) {
+            boolean success = false;
+            if (this.promise == null) {
+                this.promise = promise;
+                nameOfCallInProgress = fromCallsite;
+                success = true;
+            }
+            return success;
         }
-        return success;
     }
 
     public void resolve(Object value) {
-        if (promise == null) {
-            Log.w(MODULE_NAME, "cannot resolve promise because it's null");
-            return;
-        }
+        synchronized (this) {
+            if (promise == null) {
+                Log.w(MODULE_NAME, "cannot resolve promise because it's null");
+                return;
+            }
 
-        promise.resolve(value);
-        resetMembers();
+            promise.resolve(value);
+            resetMembers();
+        }
     }
 
     public void reject(String code, Throwable throwable) {
-        if (promise == null) {
-            Log.w(MODULE_NAME, "cannot reject promise because it's null");
-            return;
-        }
+        synchronized (this) {
+            if (promise == null) {
+                Log.w(MODULE_NAME, "cannot reject promise because it's null");
+                return;
+            }
 
-        promise.reject(code, throwable.getLocalizedMessage(), throwable);
-        resetMembers();
+            promise.reject(code, throwable.getLocalizedMessage(), throwable);
+            resetMembers();
+        }
     }
 
     public void reject(String code, String message) {
-        if (promise == null) {
-            Log.w(MODULE_NAME, "cannot reject promise because it's null");
-            return;
-        }
+        synchronized (this) {
+            if (promise == null) {
+                Log.w(MODULE_NAME, "cannot reject promise because it's null");
+                return;
+            }
 
-        promise.reject(code, message);
-        resetMembers();
+            promise.reject(code, message);
+            resetMembers();
+        }
     }
 
     public String getNameOfCallInProgress(){

--- a/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
+++ b/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
@@ -107,7 +107,8 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
 
         if (status != ConnectionResult.SUCCESS) {
             if (showPlayServicesUpdateDialog && googleApiAvailability.isUserResolvableError(status)) {
-                googleApiAvailability.getErrorDialog(activity, status, 2404).show();
+                int requestCode = 2404;
+                googleApiAvailability.getErrorDialog(activity, status, requestCode).show();
             }
             promise.reject(PLAY_SERVICES_NOT_AVAILABLE, "Play services not available");
         } else {

--- a/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
+++ b/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
@@ -56,7 +56,6 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
     public static final String PLAY_SERVICES_NOT_AVAILABLE = "PLAY_SERVICES_NOT_AVAILABLE";
     public static final String ERROR_USER_RECOVERABLE_AUTH = "ERROR_USER_RECOVERABLE_AUTH";
     private static final String SHOULD_RECOVER = "SHOULD_RECOVER";
-    private static final String TOKEN_TO_CLEAR = "TOKEN_TO_CLEAR";
 
     private PendingAuthRecovery pendingAuthRecovery;
 


### PR DESCRIPTION
this fixes the following issue: say that you call

```js
 await GoogleSignin.signInSilently();
 await GoogleSignin.signInSilently();
```

this should work but fails pretty consistently on android because the logic of `setPromiseWithInProgressCheck`, `resolve` and `resetMembers` sometimes does not get called in the right order, which manifests itself by `ASYNC_OP_IN_PROGRESS Cannot set promise. You've called "signInSilently" while "signInSilently" is already in progress and has not completed yet. Make sure you're not repeatedly calling signInSilently, signIn or revokeAccess from your JS code while the previous call has not completed yet.` even though the error is on our side.

on ios, this is much harder to reproduce (I was not able to repro) but I saw it in a log, so it seems it also happens there. I'd go with merging the PR and seeing if the message goes away.