### PR TITLE
add RNGoogleSignin pod to cocoapods example

### DIFF
--- a/docs/how-cocoapods.md
+++ b/docs/how-cocoapods.md
@@ -19,7 +19,8 @@ target 'test_google_signin' do
   # use_frameworks!
 
   # Pods for test_google_signin
-  pod 'GoogleSignIn'
+  pod 'RNGoogleSignin', :path => '../node_modules/react-native-google-signin'
+  pod 'GoogleSignIn', '~> 4.4.0' // RNGoogleSignin requires GoogleSignIn >= 4.3.0
 
   target 'test_google_signin-tvOSTests' do
     inherit! :search_paths

--- a/docs/how-cocoapods.md
+++ b/docs/how-cocoapods.md
@@ -19,7 +19,6 @@ target 'test_google_signin' do
   # use_frameworks!
 
   # Pods for test_google_signin
-  pod 'RNGoogleSignin', :path => '../node_modules/react-native-google-signin'
   pod 'GoogleSignIn', '~> 4.4.0' // RNGoogleSignin requires GoogleSignIn >= 4.3.0
 
   target 'test_google_signin-tvOSTests' do


### PR DESCRIPTION
1. add `RNGoogleSignin` pod to cocoapods example (potentially misleading not to include it)

2. Add a note about the version required for `GoogleSignIn`. This is covered [here](https://github.com/react-native-community/react-native-google-signin/blob/master/docs/ios-guide.md#with-cocoapods), but since this lib requires `>= 4.3.0` we should make sure to specify that here.