### PR TITLE
Corrects which certificate to get from Play Store

### DIFF
--- a/docs/android-guide.md
+++ b/docs/android-guide.md
@@ -175,7 +175,7 @@ signingConfigs {
 #### F. Google Login does NOT work when downloading my app from the play store.
 
 Check if "Google Play App Signing" is enabled for your app.
-If it is enabled, you will need to add the "Upload Certificate" `SHA` to your firebase console.
+If it is enabled, you will need to add the "App signing certificate" `SHA-1` to your firebase console.
 
 #### G. I did everything and I still have problems to compile my project.
 


### PR DESCRIPTION
The "App signing certificate" is the correct certificate to use - not the "Upload certificate" since that's the one from your keystore which you've already added to Firebase in a previous step.