### PR TITLE
fix typings since typescript 3.1.1

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,10 +6,10 @@
 //                 Eric Chen <https://github.com/echentw>
 
 import * as React from 'react';
-import { StyleProp, ViewProps } from 'react-native';
+import { StyleProp, ViewProps, ViewStyle } from 'react-native';
 
 export interface GoogleSigninButtonProps extends ViewProps {
-  style?: StyleProp;
+  style?: StyleProp<ViewStyle>;
   size?: GoogleSigninButton.Size;
   color?: GoogleSigninButton.Color;
   disabled?: boolean;


### PR DESCRIPTION
```
index.d.ts:12:11 - error TS2314: Generic type 'StyleProp' requires 1 type argument(s).

12   style?: StyleProp;
             ~~~~~~~~~

Found 1 error.
```

via https://github.com/Microsoft/TypeScript/issues/27421