### PR TITLE
make framework search paths more explicit

### DIFF
--- a/ios/RNGoogleSignin.xcodeproj/project.pbxproj
+++ b/ios/RNGoogleSignin.xcodeproj/project.pbxproj
@@ -236,7 +236,8 @@
 					"$(PROJECT_DIR)/**",
 					"$(SRCROOT)/../../../ios/Pods/GoogleSignIn/Frameworks",
 					"$(SRCROOT)/../example/ios/Pods/GoogleSignIn/Frameworks",
-					"$(SRCROOT)/../../../ios/**",
+					"$(SRCROOT)/../../../ios",
+					"$(SRCROOT)/../../../ios/Frameworks",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -256,7 +257,8 @@
 					"$(PROJECT_DIR)/**",
 					"$(SRCROOT)/../../../ios/Pods/GoogleSignIn/Frameworks",
 					"$(SRCROOT)/../example/ios/Pods/GoogleSignIn/Frameworks",
-					"$(SRCROOT)/../../../ios/**",
+					"$(SRCROOT)/../../../ios",
+					"$(SRCROOT)/../../../ios/Frameworks",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
a follow up on https://github.com/react-native-community/react-native-google-signin/pull/643 - I think this will be slightly better and covers the new as well as old behavior