### PR TITLE
remove GoogleAuthUtil.getToken call from default sign in process

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,6 @@ Example `userInfo` which is returned after successful sign in.
 ```
 {
   idToken: string,
-  accessTokenExpirationDate: number | null, // DEPRECATED, on iOS it's a time interval since now in seconds, on Android it's always null
   serverAuthCode: string,
   scopes: Array<string>, // on iOS this is empty array if no additional scopes are defined
   user: {

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ This method only has an effect on Android (Calling this method always resolves o
 
 #### `getTokens()`
 
-Resolves with an object containing `{ idToken: string, accessToken: string, }` or rejects with an error.
+Resolves with an object containing `{ idToken: string, accessToken: string, }` or rejects with an error. Note that using `accessToken` is [discouraged](https://developers.google.com/identity/sign-in/android/migration-guide).
 
 #### `signOut()`
 
@@ -254,7 +254,6 @@ Example `userInfo` which is returned after successful sign in.
 ```
 {
   idToken: string,
-  accessToken: string | null,
   accessTokenExpirationDate: number | null, // DEPRECATED, on iOS it's a time interval since now in seconds, on Android it's always null
   serverAuthCode: string,
   scopes: Array<string>, // on iOS this is empty array if no additional scopes are defined

--- a/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
+++ b/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
@@ -163,7 +163,12 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
     private void handleSignInTaskResult(Task<GoogleSignInAccount> result) {
         try {
             GoogleSignInAccount account = result.getResult(ApiException.class);
-            startTokenRetrievalTaskWithRecovery(account);
+            if (account == null) {
+                promiseWrapper.reject(MODULE_NAME, "GoogleSignInAccount instance was null");
+            } else {
+                WritableMap userParams = getUserProperties(account);
+                promiseWrapper.resolve(userParams);
+            }
         } catch (ApiException e) {
             int code = e.getStatusCode();
             String errorDescription = GoogleSignInStatusCodes.getStatusCodeString(code);

--- a/android/src/main/java/co/apptailor/googlesignin/Utils.java
+++ b/android/src/main/java/co/apptailor/googlesignin/Utils.java
@@ -41,7 +41,6 @@ public class Utils {
         params.putMap("user", user);
         params.putString("idToken", acct.getIdToken());
         params.putString("serverAuthCode", acct.getServerAuthCode());
-        params.putString("accessTokenExpirationDate", null); // Deprecated as of 2018-08-06
 
         WritableArray scopes = Arguments.createArray();
         for (Scope scope : acct.getGrantedScopes()) {

--- a/android/src/main/java/co/apptailor/googlesignin/Utils.java
+++ b/android/src/main/java/co/apptailor/googlesignin/Utils.java
@@ -41,7 +41,6 @@ public class Utils {
         params.putMap("user", user);
         params.putString("idToken", acct.getIdToken());
         params.putString("serverAuthCode", acct.getServerAuthCode());
-        params.putString("accessToken", null);
         params.putString("accessTokenExpirationDate", null); // Deprecated as of 2018-08-06
 
         WritableArray scopes = Arguments.createArray();

--- a/ios/RNGoogleSignin/RNGoogleSignin.m
+++ b/ios/RNGoogleSignin/RNGoogleSignin.m
@@ -187,7 +187,6 @@ RCT_EXPORT_METHOD(getTokens:(RCTPromiseResolveBlock)resolve
                            @"user": userInfo,
                            @"idToken": user.authentication.idToken,
                            @"serverAuthCode": RCTNullIfNil(user.serverAuthCode),
-                           @"accessToken": user.authentication.accessToken,
                            @"scopes": user.grantedScopes,
                            @"accessTokenExpirationDate": [NSNumber numberWithDouble:user.authentication.accessTokenExpirationDate.timeIntervalSinceNow] // Deprecated as of 2018-08-06
                            };

--- a/ios/RNGoogleSignin/RNGoogleSignin.m
+++ b/ios/RNGoogleSignin/RNGoogleSignin.m
@@ -180,7 +180,7 @@ RCT_EXPORT_METHOD(getTokens:(RCTPromiseResolveBlock)resolve
                              @"givenName": RCTNullIfNil(user.profile.givenName),
                              @"familyName": RCTNullIfNil(user.profile.familyName),
                              @"photo": imageURL ? imageURL.absoluteString : [NSNull null],
-                             @"email": user.profile.email
+                             @"email": user.profile.email,
                              };
   
   NSDictionary *params = @{
@@ -188,7 +188,6 @@ RCT_EXPORT_METHOD(getTokens:(RCTPromiseResolveBlock)resolve
                            @"idToken": user.authentication.idToken,
                            @"serverAuthCode": RCTNullIfNil(user.serverAuthCode),
                            @"scopes": user.grantedScopes,
-                           @"accessTokenExpirationDate": [NSNumber numberWithDouble:user.authentication.accessTokenExpirationDate.timeIntervalSinceNow] // Deprecated as of 2018-08-06
                            };
   return params;
 }


### PR DESCRIPTION
closes #628 

by default, on android,`signIn` and `signInSilently` call `GoogleAuthUtil.getToken` to get accessToken. Using `GoogleAuthUtil.getToken` is discouraged as seen in https://developers.google.com/identity/sign-in/android/migration-guide . This PR makes is so that `signIn` and `signInSilently` no longer make this call and thus `accessToken` is not included in the result of the call.

Obtaining accessToken is still possible using the `getTokens` call. This also removes the deprecated `accessTokenExpirationDate` since it is not available on android.

If anyone needs that value, we can add it back. This is a breaking change and will be published under a new major.