### PR TITLE
resolve with null on success

### DIFF
--- a/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
+++ b/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
@@ -130,7 +130,7 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
 
         GoogleSignInOptions options = getSignInOptions(createScopesArray(scopes), webClientId, offlineAccess, forceConsentPrompt, accountName, hostedDomain);
         _apiClient = GoogleSignIn.getClient(getReactApplicationContext(), options);
-        promise.resolve(true);
+        promise.resolve(null);
     }
 
     @ReactMethod
@@ -245,7 +245,7 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
 
     private void handleSignOutOrRevokeAccessTask(@NonNull Task<Void> task, final Promise promise) {
         if (task.isSuccessful()) {
-            promise.resolve(true);
+            promise.resolve(null);
         } else {
             int code = getExceptionCode(task);
             String errorDescription = GoogleSignInStatusCodes.getStatusCodeString(code);
@@ -391,7 +391,7 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
             }
             try {
                 GoogleAuthUtil.clearToken(moduleInstance.getReactApplicationContext(), tokenToClear[0]);
-                moduleInstance.getPromiseWrapper().resolve(true);
+                moduleInstance.getPromiseWrapper().resolve(null);
             } catch (Exception e) {
                 moduleInstance.promiseWrapper.reject(MODULE_NAME, e);
             }

--- a/index.d.ts
+++ b/index.d.ts
@@ -88,9 +88,9 @@ export interface ConfigureParams {
 
 export interface User {
   user: {
-    id: string | null;
+    id: string;
     name: string | null;
-    email: string | null;
+    email: string;
     photo: string | null;
     familyName: string | null;
     givenName: string | null;

--- a/index.d.ts
+++ b/index.d.ts
@@ -97,11 +97,6 @@ export interface User {
   };
   scopes?: string[];
   idToken: string | null;
-  accessToken: string | null;
-  /**
-   * Deprecated
-   */
-  accessTokenExpirationDate: number | null;
   /**
    * Not null only if a valid webClientId and offlineAccess: true was
    * specified in configure().
@@ -136,12 +131,12 @@ export namespace GoogleSignin {
   /**
    * Signs the user out.
    */
-  function signOut(): Promise<void>;
+  function signOut(): Promise<null>;
 
   /**
    * Removes your application from the user's authorized applications
    */
-  function revokeAccess(): Promise<void>;
+  function revokeAccess(): Promise<null>;
 
   /**
    * Returns whether the user is currently signed in
@@ -150,7 +145,7 @@ export namespace GoogleSignin {
 
   function getCurrentUser(): Promise<User | null>;
 
-  function clearCachedToken(token: string): Promise<void>;
+  function clearCachedToken(token: string): Promise<null>;
 
   function getTokens(): Promise<{ idToken: string; accessToken: string }>;
 }

--- a/index.js.flow
+++ b/index.js.flow
@@ -40,17 +40,21 @@ export type HasPlayServicesParams = $ReadOnly<{|
 |}>;
 
 export type User = {|
-  idToken: string,
-  serverAuthCode: string,
-  scopes: string[], // on iOS this is empty array if no additional scopes are defined
   user: {|
-    email: string,
     id: string,
-    givenName: ?string,
-    familyName: ?string,
+    name: ?string, // full name
+    email: string,
     photo: ?string, // url
-    name: string, // full name
+    familyName: ?string,
+    givenName: ?string,
   |},
+  scopes: string[], // on iOS this is empty array if no additional scopes are defined
+  idToken: string,
+  /**
+   * Not null only if a valid webClientId and offlineAccess: true was
+   * specified in configure().
+   */
+  serverAuthCode: ?string,
 |};
 
 // Android Status codes: https://developers.google.com/android/reference/com/google/android/gms/auth/api/signin/GoogleSignInStatusCodes

--- a/index.js.flow
+++ b/index.js.flow
@@ -41,8 +41,6 @@ export type HasPlayServicesParams = $ReadOnly<{|
 
 export type User = {|
   idToken: string,
-  accessToken: string | null,
-  accessTokenExpirationDate: number | null, // DEPRECATED, on iOS it's a time interval since now in seconds, on Android it's always null
   serverAuthCode: string,
   scopes: string[], // on iOS this is empty array if no additional scopes are defined
   user: {|
@@ -73,10 +71,10 @@ declare export class GoogleSignin {
   static configure: (params?: ConfigureParams) => void;
   static signInSilently: () => Promise<User>;
   static signIn: () => Promise<User>;
-  static signOut: () => Promise<void>;
-  static revokeAccess: () => Promise<void>;
+  static signOut: () => Promise<null>;
+  static revokeAccess: () => Promise<null>;
   static isSignedIn: () => Promise<boolean>;
   static getCurrentUser(): Promise<User | null>;
-  static clearCachedToken(token: string): Promise<void>;
+  static clearCachedToken(token: string): Promise<null>;
   static getTokens(): Promise<{ idToken: string, accessToken: string }>;
 }

--- a/ios/RNGoogleSignin/RNGoogleSignin.m
+++ b/ios/RNGoogleSignin/RNGoogleSignin.m
@@ -85,7 +85,7 @@ RCT_EXPORT_METHOD(configure:(NSDictionary *)options
     [GIDSignIn sharedInstance].serverClientID = options[@"webClientId"];
   }
 
-  resolve(@YES);
+  resolve([NSNull null]);
 }
 
 RCT_EXPORT_METHOD(signInSilently:(RCTPromiseResolveBlock)resolve
@@ -108,7 +108,7 @@ RCT_EXPORT_METHOD(signOut:(RCTPromiseResolveBlock)resolve
                   signOutReject:(RCTPromiseRejectBlock)reject)
 {
   [[GIDSignIn sharedInstance] signOut];
-  resolve(@YES);
+  resolve([NSNull null]);
 }
 
 RCT_EXPORT_METHOD(revokeAccess:(RCTPromiseResolveBlock)resolve
@@ -217,10 +217,9 @@ RCT_EXPORT_METHOD(getTokens:(RCTPromiseResolveBlock)resolve
 - (void)signIn:(GIDSignIn *)signIn didDisconnectWithUser:(GIDGoogleUser *)user withError:(NSError *)error {
   if (error) {
     [self.promiseWrapper reject:@"Error when revoking access." withError:error];
-    return;
+  } else {
+    [self.promiseWrapper resolve:[NSNull null]];
   }
-
-  [self.promiseWrapper resolve:(@YES)];
 }
 
 - (void)signIn:(GIDSignIn *)signIn presentViewController:(UIViewController *)viewController {


### PR DESCRIPTION
resolving with true, which is the current behavior, (for example with the `configure` call) might make people think it may also resolve with `false`, so I changes this and similar calls to resolve with `null` instead. It’s just a subtle change but might be breaking for some people (if they depend on the returned value)