### PR TITLE
Migrate project from rnpm to react-native.config.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,11 +42,6 @@
     "react": ">=15.4.0 || ^16.0.0-alpha",
     "react-native": ">=0.40"
   },
-  "rnpm": {
-    "ios": {
-      "project": "ios/RNGoogleSignin.xcodeproj"
-    }
-  },
   "license": "MIT",
   "devDependencies": {
     "prettier": "1.14.2"

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  project: {
+  dependency: {
     ios: {
       project: 'ios/RNGoogleSignin.xcodeproj',
     },

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  project: {
+    ios: {
+      project: 'ios/RNGoogleSignin.xcodeproj',
+    },
+  },
+};

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,7 +1,9 @@
 module.exports = {
   dependency: {
-    ios: {
-      project: 'ios/RNGoogleSignin.xcodeproj',
-    },
-  },
+    platforms: {
+      ios: {
+        project: 'ios/RNGoogleSignin.xcodeproj'
+      }
+    }
+  }
 };


### PR DESCRIPTION
# Summary
Due to an update to the RN CLI we need to migrate from rnpm to react-native.config.js.
It gets rid of the following warning
```
warn The following packages use deprecated "rnpm" config that will stop working from next release:
  - react-native-google-signin: https://github.com/react-native-community/react-native-google-signin
Please notify their maintainers about it. You can find more details at https://github.com/react-native-community/cli/blob/master/docs/configuration.md#migration-guide.
```
