### PR TITLE
mandatory style in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ render() {
 
 #### Props
 
+##### `style`
+
+Mandatory values:
+
+- width
+- height
+
+Without this, the button won't show
+
 ##### `size`
 
 Possible values:


### PR DESCRIPTION
show users that style's width and height props are required

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

When I implemented the button, I thought that `style` was not mandatory.
But my button was invisible and I spent a whole day trying lot of things.
That was just missing in documentation.

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
