### PR TITLE
do not require dimension styles for button

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Possible values:
 - Size.Standard: icon with 'Sign in'. Recommended size of 230 x 48.
 - Size.Wide: icon with 'Sign in with Google'. Recommended size of 312 x 48.
 
+Default: `Size.Standard`. Given the `size` prop you pass, we'll automatically apply the recommended size, but you can override it by passing the style prop as in `style={{ width, height }}`.
+
 ##### `color`
 
 Possible values:

--- a/example/index.js
+++ b/example/index.js
@@ -115,7 +115,6 @@ class GoogleSigninSampleApp extends Component<{}, State> {
     return (
       <View style={styles.container}>
         <GoogleSigninButton
-          style={{ width: 212, height: 48 }}
           size={GoogleSigninButton.Size.Standard}
           color={GoogleSigninButton.Color.Auto}
           onPress={this._signIn}

--- a/src/GoogleSigninButton.js
+++ b/src/GoogleSigninButton.js
@@ -7,6 +7,7 @@ import {
   ViewPropTypes,
   Platform,
   DeviceEventEmitter,
+  StyleSheet,
 } from 'react-native';
 
 const { RNGoogleSignin } = NativeModules;
@@ -21,6 +22,10 @@ export class GoogleSigninButton extends PureComponent {
     onPress: PropTypes.func.isRequired,
   };
 
+  static defaultProps = {
+    size: RNGoogleSignin.BUTTON_SIZE_STANDARD,
+  };
+
   componentDidMount() {
     if (Platform.OS === 'android') {
       this._clickListener = DeviceEventEmitter.addListener('RNGoogleSigninButtonClicked', () => {
@@ -33,12 +38,32 @@ export class GoogleSigninButton extends PureComponent {
     this._clickListener && this._clickListener.remove();
   }
 
+  getRecommendedSize() {
+    switch (this.props.size) {
+      case RNGoogleSignin.BUTTON_SIZE_ICON:
+        return styles.iconSize;
+      case RNGoogleSignin.BUTTON_SIZE_WIDE:
+        return styles.wideSize;
+      default:
+        return styles.standardSize;
+    }
+  }
+
   render() {
     const { style, ...props } = this.props;
 
-    return <RNGoogleSigninButton style={[{ backgroundColor: 'transparent' }, style]} {...props} />;
+    return <RNGoogleSigninButton style={[this.getRecommendedSize(), style]} {...props} />;
   }
 }
+
+const styles = StyleSheet.create({
+  iconSize: {
+    width: 48,
+    height: 48,
+  },
+  standardSize: { width: 212, height: 48 },
+  wideSize: { width: 312, height: 48 },
+});
 
 GoogleSigninButton.Size = {
   Icon: RNGoogleSignin.BUTTON_SIZE_ICON,


### PR DESCRIPTION
this is a more user-friendly alternative to https://github.com/react-native-community/react-native-google-signin/pull/702