### PR TITLE
Change package name on auto linking for RN < 0.60

### DIFF
--- a/docs/ios-guide.md
+++ b/docs/ios-guide.md
@@ -12,7 +12,7 @@ You can link the module automatically or manually
 
 - in RN >= 0.60 run `pod install` in `ios/` directory to install the module
 
-- in RN < 0.60 run `react-native link @react-native-community/google-signin`
+- in RN < 0.60 run `react-native link react-native-google-signin`
 
 ##### manual linking
 


### PR DESCRIPTION
In the Project Setup section there is the information to use react-native-google-signin packge to RN < 0.60.