### PR TITLE
add token clearing to example

### DIFF
--- a/example/TokenClearingView.js
+++ b/example/TokenClearingView.js
@@ -1,0 +1,25 @@
+// @flow
+import React, { useState, useCallback } from 'react';
+import { Button, TextInput } from 'react-native';
+import type { User } from '@react-native-community/google-signin';
+import { GoogleSignin } from '@react-native-community/google-signin';
+export function TokenClearingView({ userInfo }: { userInfo: User }) {
+  const [tokenToClear, setToken] = useState(userInfo.idToken);
+  const clearToken = useCallback(
+    async () => {
+      try {
+        await GoogleSignin.clearCachedToken(tokenToClear);
+        console.warn('success!');
+      } catch (err) {
+        console.error(err);
+      }
+    },
+    [tokenToClear]
+  );
+  return (
+    <>
+      <TextInput onChangeText={setToken} value={tokenToClear} style={{ height: 50, width: 200 }} />
+      <Button title="clear token" onPress={clearToken} />
+    </>
+  );
+}

--- a/example/index.js
+++ b/example/index.js
@@ -8,6 +8,7 @@ import {
 } from '@react-native-community/google-signin';
 import type { User } from '@react-native-community/google-signin';
 import config from './config'; // see docs/CONTRIBUTING.md for details
+import { TokenClearingView } from './TokenClearingView';
 
 type ErrorWithCode = Error & { code?: string };
 
@@ -104,6 +105,7 @@ class GoogleSigninSampleApp extends Component<{}, State> {
           Welcome {userInfo.user.name}
         </Text>
         <Text>Your user info: {JSON.stringify(userInfo.user)}</Text>
+        <TokenClearingView userInfo={userInfo} />
 
         <Button onPress={this._signOut} title="Log out" />
         {this.renderError()}

--- a/src/GoogleSignin.js
+++ b/src/GoogleSignin.js
@@ -66,7 +66,7 @@ class GoogleSignin {
     if (!tokenString || typeof tokenString !== 'string') {
       return Promise.reject(`GoogleSignIn: clearCachedToken() expects a string token.`);
     }
-    return IS_IOS ? true : !!(await RNGoogleSignin.clearCachedToken(tokenString));
+    return IS_IOS ? true : !(await RNGoogleSignin.clearCachedToken(tokenString));
   }
 
   async getTokens() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This adds the `clearCachedToken` functionality to example.
while I was at it, I noticed the returned value is `true` on iOS and `false` on android, so I fixed that. We should probably return null, since the boolean carries no value here, but that could be a breaking change.

## Test Plan

runs on iOS and android Emulators

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [x] I added a sample use of the API in the example project (`example/App.js`)
