### PR TITLE
Fixes exception 'presentingViewController must be set.'

### DIFF
--- a/ios/RNGoogleSignin/RNGoogleSignin.m
+++ b/ios/RNGoogleSignin/RNGoogleSignin.m
@@ -66,7 +66,6 @@ RCT_EXPORT_METHOD(configure:(NSDictionary *)options
   }
 
   [GIDSignIn sharedInstance].delegate = self;
-  [GIDSignIn sharedInstance].presentingViewController = RCTPresentedViewController();
   [GIDSignIn sharedInstance].scopes = options[@"scopes"];
   [GIDSignIn sharedInstance].shouldFetchBasicProfile = YES; // email, profile
   [GIDSignIn sharedInstance].loginHint = options[@"loginHint"];
@@ -99,6 +98,7 @@ RCT_EXPORT_METHOD(signInSilently:(RCTPromiseResolveBlock)resolve
 RCT_EXPORT_METHOD(signIn:(RCTPromiseResolveBlock)resolve
                   signInReject:(RCTPromiseRejectBlock)reject)
 {
+  [GIDSignIn sharedInstance].presentingViewController = RCTPresentedViewController();
   if ([self.promiseWrapper setPromiseWithInProgressCheck:resolve rejecter:reject fromCallSite:@"signIn"]) {
     [[GIDSignIn sharedInstance] signIn];
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
Moved RCTPresentedViewController to singIn method to request actual RCTPresentedViewController each time on action being called.
Closes #761 

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
- react-native 0.61.2
- @react-native-community/google-signin version 3.0.2
- react-navigation version 4.0.10
- iOS 13.1
- Xcode 11.1

### What are the steps to reproduce (after prerequisites)?
Call `GoogleSignin.configure()` in App.js useEffect() hook, create a seconf screen with Google Sign In button and try to sign in, it will break if built using release scheme.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    -     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
