### PR TITLE
Don't reference Facebook SDK?

### DIFF
--- a/docs/ios-guide.md
+++ b/docs/ios-guide.md
@@ -71,6 +71,6 @@ Because only one `openURL` method can be defined, if you have multiple listeners
 ```objc
 // AppDelegate.m
 - (BOOL)application:(UIApplication *)application openURL:(nonnull NSURL *)url options:(nonnull NSDictionary<NSString *,id> *)options {
-  return [[FBSDKApplicationDelegate sharedInstance] application:application openURL:url options:options] || [RNGoogleSignin application:application openURL:url options:options];
+  return [RNGoogleSignin application:application openURL:url options:options];
 }
 ```


### PR DESCRIPTION
# Summary
I think this has to be a bad copy and paste? For some reason we were referencing the Facebook SDK (in additional to the Google SDK) in the iOS instructions? 

If this isn't a typo I can't imagine why it'd be included.

## Test Plan
N/A

## Checklist
None of these seem relevant but please let me know if you disagree?

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
