### PR TITLE
Update android-guide.md

### DIFF
--- a/docs/android-guide.md
+++ b/docs/android-guide.md
@@ -22,7 +22,7 @@ Please note that this package requires android gradle plugin of version >= 3, wh
 
 in RN >= 0.60 you should not need to do anything thanks to [autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md)
 
-in RN < 0.60 run `react-native link @react-native-community/google-signin`
+in RN < 0.60 run `react-native link react-native-google-signin`
 
 2 . Update `android/build.gradle` with
 


### PR DESCRIPTION
I believe that this line: in RN < 0.60 run `react-native link @react-native-community/google-signin` should be replaced to: in RN < 0.60 run `react-native link react-native-google-signin` since for RN < 0.60 the readme recommends to use version 2.